### PR TITLE
Standardize PHP open tags

### DIFF
--- a/adm-addmulti.php
+++ b/adm-addmulti.php
@@ -1,4 +1,4 @@
-<?PHP
+<?php
 include("config.php");
   $dbres = mysql_query("SELECT *,UNIX_TIMESTAMP(`pc`) AS `pc`,UNIX_TIMESTAMP(`transport`) AS `transport`,UNIX_TIMESTAMP(`bc`) AS `bc`,UNIX_TIMESTAMP(`slaap`) AS `slaap`,UNIX_TIMESTAMP(`kc`) AS `kc`,UNIX_TIMESTAMP(`start`) AS `start`,UNIX_TIMESTAMP(`crime`) AS `crime`,UNIX_TIMESTAMP(`ac`) AS `ac` FROM `users` WHERE `login`='{$_SESSION['login']}'");
   $data	= mysql_fetch_object($dbres);
@@ -19,7 +19,7 @@ if ($data->level < 200) {exit; }
   <tr><td>&nbsp;&nbsp;</td></tr>
   <tr> 
     <td class="mainTxt"><a href=adm-search.php?p=multi>Multi Account Scan</a><br><br>
-<?
+<?php
 if (isset($_GET['del'])) {
 $ip = mysql_fetch_object(mysql_query("SELECT * FROM `multiple` WHERE `ip`='{$_GET['del']}'"));
 if ($ip->ip != $_GET['del']) { echo "Dit ip adres staat niet in de lijst."; }

--- a/adm-addnews.php
+++ b/adm-addnews.php
@@ -1,4 +1,4 @@
-<?
+<?php
 include("config.php");
 $dbres = mysql_query("SELECT * FROM `users` WHERE `login`='{$_SESSION['login']}'");
 $data = mysql_fetch_object($dbres);
@@ -22,7 +22,7 @@ if($data->level == 1){
 
 
 <body>
-<?
+<?php
 if(isset($_POST['addnew'])){
   if(!isset($_POST['title'])){echo"Je hebt geen titel opgegeven.";exit;}
   if(!isset($_POST['text'])){echo"Je hebt geen tekst opgegeven.";exit;}
@@ -68,7 +68,7 @@ if($_GET['page']=="addnews"){
   </tr>  
 </table>
 
-<?
+<?php
 }
 elseif(isset($_GET['d'])){
   $id = $_GET['d'];
@@ -88,14 +88,14 @@ elseif(isset($_GET['d'])){
   <tr>
     <td class="mainTxt"><form method=post>
 	                    Bent u zeker dat u dit nieuws wilt verwijderen?<br>
-						Nr <? echo $id; ?> <i><b><? echo $title; ?></b></i> <? echo $time; ?> <br><br><? echo $text; ?>
-						<input type=hidden name=id value=<? echo $id; ?>><br>
+						Nr <?php echo $id; ?> <i><b><?php echo $title; ?></b></i> <?php echo $time; ?> <br><br><?php echo $text; ?>
+						<input type=hidden name=id value=<?php echo $id; ?>><br>
 						<input type=submit name=del value=Ja>
 						</form>
 	</td>
   </tr>  
 </table>
-<?
+<?php
 }
 elseif($_GET['page']=="delnews" || isset($_GET['p'])){
 ?>
@@ -108,7 +108,7 @@ elseif($_GET['page']=="delnews" || isset($_GET['p'])){
   </tr>
   <tr>
     <td class="mainTxt">**********<br>
-	  <?
+	  <?php
 	  $pp = 10;
 	  $start= ($_GET['p'] >= 0) ? $_GET['p']*$pp : 0;
 	  $sql = mysql_query("SELECT id FROM `news`");
@@ -154,7 +154,7 @@ elseif($_GET['page']=="delnews" || isset($_GET['p'])){
 	</td>
   </tr>
 </table>
-<?
+<?php
 }
 elseif(isset($_GET['x'])){
   $id = $_GET['x'];
@@ -173,16 +173,16 @@ elseif(isset($_GET['x'])){
   </tr>
   <tr>
     <td class="mainTxt"><form method=post>
-	                    Titel: <input type=text name=title value="<? echo $title; ?>"><br>
-						Tekst: <textarea name=text rows=10	cols=50 onkeypress=textCounter(this,this.form.counter,999);><? echo $text; ?></TEXTAREA><br>
+	                    Titel: <input type=text name=title value="<?php echo $title; ?>"><br>
+						Tekst: <textarea name=text rows=10	cols=50 onkeypress=textCounter(this,this.form.counter,999);><?php echo $text; ?></TEXTAREA><br>
 						Tijd updaten: <input type=checkbox name=t value=1><br>
-						<input type=hidden name=id value=<? echo $id; ?>><input type=hidden name=time value=<? echo $time; ?>>
+						<input type=hidden name=id value=<?php echo $id; ?>><input type=hidden name=time value=<?php echo $time; ?>>
 						<input type=submit name=edit value=Ja>
 						</form>
 	</td>
   </tr>  
 </table>
-<?
+<?php
 }
 elseif($_GET['page']=="editnews" || isset($_GET['e'])){
 ?>
@@ -195,7 +195,7 @@ elseif($_GET['page']=="editnews" || isset($_GET['e'])){
   </tr>
   <tr>
     <td class="mainTxt">**********<br>
-	  <?
+	  <?php
 	  $pp = 10;
 	  $start= ($_GET['e'] >= 0) ? $_GET['e']*$pp : 0;
 	  $sql = mysql_query("SELECT id FROM `news`");
@@ -241,7 +241,7 @@ elseif($_GET['page']=="editnews" || isset($_GET['e'])){
 	</td>
   </tr>
 </table>
-<?
+<?php
 }
 else{
 ?>
@@ -256,7 +256,7 @@ else{
     <td class=mainTxt><table width="100%"><tr><td width="50%"><a href=?page=addnews>Nieuws toevoegen</a></td><td><a href=?page=delnews>Nieuws verwijderen</a></td></tr><tr><td><a href=?page=editnews>Nieuws bewerken</a></td><td>&nbsp;</td></tr></table></td>
   </tr>
 </table>
-<?
+<?php
 }
 ?>
 </body>

--- a/adm-ban.php
+++ b/adm-ban.php
@@ -1,4 +1,4 @@
-<?PHP
+<?php
 include("config.php");
   $dbres = mysql_query("SELECT *,UNIX_TIMESTAMP(`pc`) AS `pc`,UNIX_TIMESTAMP(`transport`) AS `transport`,UNIX_TIMESTAMP(`bc`) AS `bc`,UNIX_TIMESTAMP(`slaap`) AS `slaap`,UNIX_TIMESTAMP(`kc`) AS `kc`,UNIX_TIMESTAMP(`start`) AS `start`,UNIX_TIMESTAMP(`crime`) AS `crime`,UNIX_TIMESTAMP(`ac`) AS `ac` FROM `users` WHERE `login`='{$_SESSION['login']}'");
   $data	= mysql_fetch_object($dbres);
@@ -19,7 +19,7 @@ include("config.php");
   <tr><td>&nbsp;&nbsp;</td></tr>
   <tr> 
     <td class="mainTxt">
-<?
+<?php
 if ($data->level < 255) { print "Je hebt niet voldoende rechten.";exit; }
 $ip = $_POST['ip'];
 $reden = $_POST['reden'];

--- a/adm-cleandb.php
+++ b/adm-cleandb.php
@@ -1,4 +1,4 @@
-<?
+<?php
 include("config.php");
 $blah = mysql_query("SELECT * FROM `users` WHERE `status`='dood'");
 while($user = mysql_fetch_object($blah)) {

--- a/adm-drdrpr.php
+++ b/adm-drdrpr.php
@@ -1,4 +1,4 @@
-<?PHP
+<?php
 include("config.php");
   $dbres = mysql_query("SELECT *,UNIX_TIMESTAMP(`pc`) AS `pc`,UNIX_TIMESTAMP(`transport`) AS `transport`,UNIX_TIMESTAMP(`bc`) AS `bc`,UNIX_TIMESTAMP(`slaap`) AS `slaap`,UNIX_TIMESTAMP(`kc`) AS `kc`,UNIX_TIMESTAMP(`start`) AS `start`,UNIX_TIMESTAMP(`crime`) AS `crime`,UNIX_TIMESTAMP(`ac`) AS `ac` FROM `users` WHERE `login`='{$_SESSION['login']}'");
   $data	= mysql_fetch_object($dbres);
@@ -19,7 +19,7 @@ if ($data->level < 200) { exit; }
   <tr><td>&nbsp;&nbsp;</td></tr>
   <tr> 
     <td class="mainTxt">
-<?PHP
+<?php
 if ($_POST['submit']) {
 $abrussel = rand(1000,6000);
 $aleuven = rand(1000,6000);

--- a/adm-forum.php
+++ b/adm-forum.php
@@ -1,4 +1,4 @@
-<?PHP
+<?php
 include("config.php");
   $dbres = mysql_query("SELECT *,UNIX_TIMESTAMP(`pc`) AS `pc`,UNIX_TIMESTAMP(`transport`) AS `transport`,UNIX_TIMESTAMP(`bc`) AS `bc`,UNIX_TIMESTAMP(`slaap`) AS `slaap`,UNIX_TIMESTAMP(`kc`) AS `kc`,UNIX_TIMESTAMP(`start`) AS `start`,UNIX_TIMESTAMP(`crime`) AS `crime`,UNIX_TIMESTAMP(`ac`) AS `ac` FROM `users` WHERE `login`='{$_SESSION['login']}'");
   $data	= mysql_fetch_object($dbres);

--- a/adm-items.php
+++ b/adm-items.php
@@ -1,4 +1,4 @@
-<?PHP
+<?php
 include("config.php");
   $dbres = mysql_query("SELECT *,UNIX_TIMESTAMP(`pc`) AS `pc`,UNIX_TIMESTAMP(`transport`) AS `transport`,UNIX_TIMESTAMP(`bc`) AS `bc`,UNIX_TIMESTAMP(`slaap`) AS `slaap`,UNIX_TIMESTAMP(`kc`) AS `kc`,UNIX_TIMESTAMP(`start`) AS `start`,UNIX_TIMESTAMP(`crime`) AS `crime`,UNIX_TIMESTAMP(`ac`) AS `ac` FROM `users` WHERE `login`='{$_SESSION['login']}'");
   $data	= mysql_fetch_object($dbres);

--- a/adm-msg.php
+++ b/adm-msg.php
@@ -1,4 +1,4 @@
-<?PHP
+<?php
 include("config.php");
   $dbres = mysql_query("SELECT *,UNIX_TIMESTAMP(`pc`) AS `pc`,UNIX_TIMESTAMP(`transport`) AS `transport`,UNIX_TIMESTAMP(`bc`) AS `bc`,UNIX_TIMESTAMP(`slaap`) AS `slaap`,UNIX_TIMESTAMP(`kc`) AS `kc`,UNIX_TIMESTAMP(`start`) AS `start`,UNIX_TIMESTAMP(`crime`) AS `crime`,UNIX_TIMESTAMP(`ac`) AS `ac` FROM `users` WHERE `login`='{$_SESSION['login']}'");
   $data	= mysql_fetch_object($dbres);
@@ -20,7 +20,7 @@ if ($data->level < 200) { exit; }
   <tr><td>&nbsp;&nbsp;</td></tr>
   <tr> 
     <td class="mainTxt">
-<?
+<?php
 if (isset($_POST['submit'])) {
           if ($_POST['to']!="") {
 $_POST['subject']		= preg_replace('/</','&#60;',$_POST['subject']);

--- a/adm-online.php
+++ b/adm-online.php
@@ -1,4 +1,4 @@
-<?PHP
+<?php
 include("config.php");
   $dbres = mysql_query("SELECT *,UNIX_TIMESTAMP(`pc`) AS `pc`,UNIX_TIMESTAMP(`transport`) AS `transport`,UNIX_TIMESTAMP(`bc`) AS `bc`,UNIX_TIMESTAMP(`slaap`) AS `slaap`,UNIX_TIMESTAMP(`kc`) AS `kc`,UNIX_TIMESTAMP(`start`) AS `start`,UNIX_TIMESTAMP(`crime`) AS `crime`,UNIX_TIMESTAMP(`ac`) AS `ac` FROM `users` WHERE `login`='{$_SESSION['login']}'");
   $data	= mysql_fetch_object($dbres);
@@ -24,7 +24,7 @@ if ($data->level < 200) { exit; }
     <td width='30%'><center><b>Login</b></center></td>
     <td width='45%'><center><b>Rang</b></center></td>
   </tr>
-<?PHP
+<?php
 
 
 if ($data->level < 200) { exit; }

--- a/adm-poll.php
+++ b/adm-poll.php
@@ -1,4 +1,4 @@
-<?PHP
+<?php
 include("config.php");
   $dbres = mysql_query("SELECT *,UNIX_TIMESTAMP(`pc`) AS `pc`,UNIX_TIMESTAMP(`transport`) AS `transport`,UNIX_TIMESTAMP(`bc`) AS `bc`,UNIX_TIMESTAMP(`slaap`) AS `slaap`,UNIX_TIMESTAMP(`kc`) AS `kc`,UNIX_TIMESTAMP(`start`) AS `start`,UNIX_TIMESTAMP(`crime`) AS `crime`,UNIX_TIMESTAMP(`ac`) AS `ac` FROM `users` WHERE `login`='{$_SESSION['login']}'");
   $data	= mysql_fetch_object($dbres);

--- a/adm-prison.php
+++ b/adm-prison.php
@@ -19,7 +19,7 @@ if ($data->level < 200) { exit; }
   <tr><td>&nbsp;&nbsp;</td></tr>
   <tr> 
     <td class="mainTxt">
-	<?PHP 
+	<?php 
 
 if(isset($_POST['putin'])) {
 if($data->level < 255) {echo"Je hebt niet genoeg rechten.";exit;}

--- a/adm-search.php
+++ b/adm-search.php
@@ -1,4 +1,4 @@
-<?
+<?php
 include("config.php");
   $dbres = mysql_query("SELECT *,UNIX_TIMESTAMP(`pc`) AS `pc`,UNIX_TIMESTAMP(`transport`) AS `transport`,UNIX_TIMESTAMP(`bc`) AS `bc`,UNIX_TIMESTAMP(`slaap`) AS `slaap`,UNIX_TIMESTAMP(`kc`) AS `kc`,UNIX_TIMESTAMP(`start`) AS `start`,UNIX_TIMESTAMP(`crime`) AS `crime`,UNIX_TIMESTAMP(`ac`) AS `ac` FROM `users` WHERE `login`='{$_SESSION['login']}'");
   $data	= mysql_fetch_object($dbres);
@@ -19,7 +19,7 @@ if ($data->level < 200) { exit; }
   <tr><td>&nbsp;&nbsp;</td></tr>
   <tr> 
     <td class="mainTxt">
-<?
+<?php
 if (isset($_GET['login'])) { 
 $_SESSION['login'] = $_GET['login'];
 $blabla = mysql_query("SELECT * FROM `users` WHERE `login`='{$_GET['login']}'");

--- a/adm-shame.php
+++ b/adm-shame.php
@@ -1,4 +1,4 @@
-<?PHP
+<?php
 include("config.php");
   $dbres = mysql_query("SELECT *,UNIX_TIMESTAMP(`pc`) AS `pc`,UNIX_TIMESTAMP(`transport`) AS `transport`,UNIX_TIMESTAMP(`bc`) AS `bc`,UNIX_TIMESTAMP(`slaap`) AS `slaap`,UNIX_TIMESTAMP(`kc`) AS `kc`,UNIX_TIMESTAMP(`start`) AS `start`,UNIX_TIMESTAMP(`crime`) AS `crime`,UNIX_TIMESTAMP(`ac`) AS `ac` FROM `users` WHERE `login`='{$_SESSION['login']}'");
   $data	= mysql_fetch_object($dbres);
@@ -19,7 +19,7 @@ if ($data->level < 200) { exit; }
   <tr><td>&nbsp;&nbsp;</td></tr>
   <tr> 
     <td class="mainTxt">
-<?
+<?php
 if ($data->level < 1000) {echo"Je hebt niet genoeg rechten";exit;}
 if (isset($_GET['del'])) { mysql_query("DELETE FROM `shame` WHERE `id`='{$_GET['del']}'")or die (mysql_error()); echo "Verwijderd"; }
 

--- a/adm-warn.php
+++ b/adm-warn.php
@@ -1,4 +1,4 @@
-<?PHP
+<?php
 include("config.php");
   $dbres = mysql_query("SELECT *,UNIX_TIMESTAMP(`pc`) AS `pc`,UNIX_TIMESTAMP(`transport`) AS `transport`,UNIX_TIMESTAMP(`bc`) AS `bc`,UNIX_TIMESTAMP(`slaap`) AS `slaap`,UNIX_TIMESTAMP(`kc`) AS `kc`,UNIX_TIMESTAMP(`start`) AS `start`,UNIX_TIMESTAMP(`crime`) AS `crime`,UNIX_TIMESTAMP(`ac`) AS `ac` FROM `users` WHERE `login`='{$_SESSION['login']}'");
   $data	= mysql_fetch_object($dbres);
@@ -20,7 +20,7 @@ if ($data->level < 200) { exit; }
   <tr> 
     <td class="mainTxt">
 
-<?
+<?php
 if($data->level < 255) {echo"Je hebt niet genoeg rechten.";exit;}
 $user = $_GET['x'];
     mysql_query("INSERT INTO `messages`(`time`,`from`,`to`,`subject`,`message`) values(NOW(),'Notificatie','$user','Waarschuwing','Er is meer dan 1 account op je ip gevonden, dit is tegen de regels. Stuur een bericht naar een admin om je tweede account te rechtvaardigen, anders is de kans groot dat een van je accounts verwijderd wordt.(Verzonden door $data->login)')"); 

--- a/admin.php
+++ b/admin.php
@@ -1,4 +1,4 @@
-<? 
+<?php 
 session_start();
 include("config.php"); 
 $username = $HTTP_POST_VARS["username"];  
@@ -14,7 +14,7 @@ if($submit){
 }
 if($_SESSION[login] + 60*60*24 > time()){
 ?>
-<form name="form2" method="post" action="<? echo"$PHP_SELF"; ?>">Al de berichten wissen:<br>
+<form name="form2" method="post" action="<?php echo"$PHP_SELF"; ?>">Al de berichten wissen:<br>
     <input name="wissen" type="submit" value="Berichten Wissen"><br>Je instellingen wijzigen:<br>
 	<input name="wijzigen" type="submit" value="Instellingen Wijzigen">
   <br>
@@ -24,7 +24,7 @@ if($_SESSION[login] + 60*60*24 > time()){
   Je uitloggen (anders blijf je 1 dag ingelogd!):<br>
 	<input name="uitloggen" type="submit" value="Uitloggen">
 </form>
-<?
+<?php
 	if($uitloggen){
 		session_unregister('login');
 	}
@@ -41,7 +41,7 @@ if($_SESSION[login] + 60*60*24 > time()){
 	if($veranderen){
 ?>
 <form name="form3" method="post" action="verander.php">
-<?
+<?php
 if(!$bestand){
 	echo"<b>Er zijn nog geen berichten</b><br>";
 }
@@ -53,78 +53,78 @@ echo"<input name=verander type=submit value=Wijzigen>";
 }
 ?>
 </form>
-<?
+<?php
 	}
 	if($wijzigen){
 ?>
 <b><form name="form3" method="post" action="wijzig.php">
   <p>Je gebruikersnaam: <br>
-    <input name="text" type="text" value="<? echo"$admin"; ?>">
+    <input name="text" type="text" value="<?php echo"$admin"; ?>">
     <br>
     Je wachtwoord:<br>
-    <input name="text2" type="password" value="<? echo"$paswoord"; ?>">
+    <input name="text2" type="password" value="<?php echo"$paswoord"; ?>">
     <br>
     De tekst die moet komen als iemand een fout wachtwoord of gebruikersnaam heeft 
     ingetypt: <br>
-    <input name="text3" type="text" value="<? echo"$fout"; ?>">
+    <input name="text3" type="text" value="<?php echo"$fout"; ?>">
     <br>
     Nieuwe berichten vooraan = &quot;nieuwe&quot; oude = &quot;oude&quot;<br>
-    <input name="text4" type="text" value="<? echo"$vooraan"; ?>">
+    <input name="text4" type="text" value="<?php echo"$vooraan"; ?>">
     <br>
     Maximum aantal karakters dat ze mogen in hun naam:<br>
-    <input name="text5" type="text" value="<? echo"$maxn"; ?>">
+    <input name="text5" type="text" value="<?php echo"$maxn"; ?>">
     <br>
     Maximum aantal karakters dat ze mogen in hun bericht: <br>
-    <input name="text6" type="text" value="<? echo"$maxb"; ?>">
+    <input name="text6" type="text" value="<?php echo"$maxb"; ?>">
     <br>
     Als je vanboven nieuwe had aangeduid hoeveel berichten mogen dan in de balk 
     staan:<br>
-    <input name="text7" type="text" value="<? echo"$max"; ?>">
+    <input name="text7" type="text" value="<?php echo"$max"; ?>">
     <br>
     Het bestand waar in geschreven moet worden:<br>
-    <input name="text8" type="text" value="<? echo"$file"; ?>">
+    <input name="text8" type="text" value="<?php echo"$file"; ?>">
     <br>
     Het bestand waar het formpje staat:<br>
-    <input name="text9" type="text" value="<? echo"$form"; ?>">
+    <input name="text9" type="text" value="<?php echo"$form"; ?>">
     <br>
 	Het bestand waar de berichtenbalk staat:<br>
-    <input name="text18" type="text" value="<? echo"$bar"; ?>">
+    <input name="text18" type="text" value="<?php echo"$bar"; ?>">
     <br>
     De tekst die er moet komen als er nog geen berichten zijn:<br>
-    <input name="text11" type="text" value="<? echo"$leeg"; ?>">
+    <input name="text11" type="text" value="<?php echo"$leeg"; ?>">
     <br>
     Wat er moet komen als ze niks hebben ingevuld:<br>
-    <input name="text12" type="text" value="<? echo"$ongeldig"; ?>">
+    <input name="text12" type="text" value="<?php echo"$ongeldig"; ?>">
     <br>
     De scheiding tussen twee berichten:<br>
-    <input name="text13" type="text" value="<? echo"$tussen"; ?>">
+    <input name="text13" type="text" value="<?php echo"$tussen"; ?>">
     <br>
     Wat er moet komen als het bericht gepost is:<br>
-    <input name="text14" type="text" value="<? echo"$post"; ?>">
+    <input name="text14" type="text" value="<?php echo"$post"; ?>">
     <br>
     De map waar de afbeeldingen staan(zonder eind&quot;/&quot;):<br>
-    <input name="text15" type="text" value="<? echo"$dir"; ?>">
+    <input name="text15" type="text" value="<?php echo"$dir"; ?>">
     <br>
     Het aantal seconden dat de gebruiker moet wachten voor hij nog eens mag posten:<br>
-    <input name="text16" type="text" value="<? echo"$verlooptijd"; ?>">
+    <input name="text16" type="text" value="<?php echo"$verlooptijd"; ?>">
     <br>
 	Als ze te snel na elkaar een bericht gepost hebben:<br>
-    <input name="text17" type="text" value="<? echo"$flood"; ?>">
+    <input name="text17" type="text" value="<?php echo"$flood"; ?>">
     <br>
     <input type="submit" name="wijzig" value="Wijzigen">
   </p>
 </form>
 </b>
-<?
+<?php
 	}	
 }
 else{
 ?>  
-<form name="form1" method="post" action="<? echo"$PHP_SELF"; ?>"><p>Gebruikersnaam: 
+<form name="form1" method="post" action="<?php echo"$PHP_SELF"; ?>"><p>Gebruikersnaam: 
     <input name="username" type="text" id="username">Paswoord: 
     <input name="password" type="password" id="password">      
     <input name="submit" type="submit" id="submit" value="Login"> 
 </form> 
-<?  
+<?php  
 }
 ?>

--- a/ban.php
+++ b/ban.php
@@ -1,4 +1,4 @@
-<?
+<?php
 $host = gethostbyaddr($_SERVER['REMOTE_ADDR']);  
 $parts = explode('.', $host);
 if ($parts[count($parts)-1] != "be" && $parts[count($parts)-1] != "nl"){

--- a/bar.php
+++ b/bar.php
@@ -2,7 +2,7 @@
   <tr>
     <td valign="center">
 <marquee>
-<? 
+<?php 
 include("config.php");
 for($i = 0; $i <= $hits; $i++){
 $getal[$i] =  str_replace(":-s", "<img src=\"$dir/smilie1.gif\" border=\"0\">", $getal[$i]); 

--- a/berichtenbalk.php
+++ b/berichtenbalk.php
@@ -1,11 +1,11 @@
-<? include("config.php"); // config includen voor al de gegevens ?>
-<iframe src="<? echo "$bar"; ?>" frameborder="0" width="100%" height="*" name="main" scrolling="no"></iframe>
+<?php include("config.php"); // config includen voor al de gegevens ?>
+<iframe src="<?php echo "$bar"; ?>" frameborder="0" width="100%" height="*" name="main" scrolling="no"></iframe>
 <table height="*" width="*" align="center" valign="middle" style="font-family: verdana">
   <tr> 
     <td align="center"> <table style="border: 1px solid black; font-size: 10pt;" cellpadding="2" cellspacing="5">
         <tr> 
           <td align="center">Status:<br><b>Je kan nu een bericht intypen!</b>
-<?
+<?php
 session_start();  
 function htmlparse($string){ 
 	return htmlentities(trim($string), ENT_QUOTES); 
@@ -28,13 +28,13 @@ if ($_POST[Submit]){
 		$tijd = time();  
 		session_register("tijd");  
 		$open = fopen("$file", "a");  
-		fputs($open, "<?\n");  
+		fputs($open, "<?php\n");  
 		fputs($open, '$getal');  
 		fputs($open, "[$hits]");  
 		fputs($open, " = \"<b>$naam:</b> $bericht <b>$tussen</b> \";\n");  
 		fputs($open, "?>\n");  
 		fclose($open);
 		echo("<br>
-            <b>$post</b>"); } } include("$form"); ?> <a href="bar.php" target="main"><img src="<? echo "$dir"; ?>/www.gif" border="0">Vernieuwen</a> 
-            / <a href="admin.php"><img src="<? echo "$dir"; ?>/admin.gif" border="0">Admin</a></TD>
+            <b>$post</b>"); } } include("$form"); ?> <a href="bar.php" target="main"><img src="<?php echo "$dir"; ?>/www.gif" border="0">Vernieuwen</a> 
+            / <a href="admin.php"><img src="<?php echo "$dir"; ?>/admin.gif" border="0">Admin</a></TD>
         </TR></TABLE></TD></TR></TABLE></TD></TR></TABLE></TD></TR></TABLE>

--- a/blackjack.php
+++ b/blackjack.php
@@ -23,7 +23,7 @@ if ($jisin == 1) { header('Location: jisin.php'); }
   <tr><td>&nbsp;&nbsp;</td></tr>
   <tr> 
     <td class="mainTxt">
-<?PHP
+<?php
 $picurl = "http://members.lycos.nl/js6287/images/kaarten/";
 $ext = ".jpg";
 $dbres = mysql_query("SELECT * FROM `casino` WHERE `spel`='blackjack' AND `stad`='$data->stad'") or die (mysql_error());

--- a/blackmarket.php
+++ b/blackmarket.php
@@ -24,7 +24,7 @@ if ($jisin == 1) { header('Location: jisin.php'); }
   <tr><td>&nbsp;&nbsp;</td></tr>
   <tr> 
     <td class=mainTxt>
-<?
+<?php
 $kogels = mysql_num_rows(mysql_query("SELECT * FROM `mshop` WHERE `type`='bullet'"))or die(mysql_error());
 $ws = mysql_num_rows(mysql_query("SELECT * FROM `mshop` WHERE `type`='ws'"))or die(mysql_error());
 $car = mysql_num_rows(mysql_query("SELECT * FROM `mshop` WHERE `type`='car'"))or die(mysql_error());

--- a/bloodbank.php
+++ b/bloodbank.php
@@ -17,7 +17,7 @@ if ($jisin == 1) { header("Location: jisin.php"); }
 <meta name="language" content="english">
 <META name="description" lang="nl" content="Vendetta crimegame met pit.">
 </head>
-<?PHP
+<?php
 print <<<ENDHTML
 <table width="100%" align=center>
 <tr> 

--- a/bulletfactory.php
+++ b/bulletfactory.php
@@ -16,7 +16,7 @@ if ($jisin == 1) { header('Location: jisin.php'); }
 <meta name="language" content="english">
 <META name="description" lang="nl" content="Vendetta crimegame met pit.">
 </head>
-<?PHP
+<?php
 print <<<ENDHTML
 <table width="100%" align=center>
 <tr> 

--- a/carrace.php
+++ b/carrace.php
@@ -16,7 +16,7 @@ if ($jisin == 1) { header('Location: jisin.php'); }
 <meta name="language" content="english">
 <META name="description" lang="nl" content="Vendetta crimegame met pit.">
 </head>
-<?PHP
+<?php
 print <<<ENDHTML
 <table width=100%> 
   <tr> 

--- a/crime.php
+++ b/crime.php
@@ -17,7 +17,7 @@ if ($jisin == 1) { header('Location: jisin.php'); }
 <meta name="language" content="english">
 <META name="description" lang="nl" content="Vendetta crimegame met pit.">
 </head>
-<?PHP
+<?php
 print <<<ENDHTML
 <table width=100% align=center>
   <tr> 
@@ -59,7 +59,7 @@ elseif($_POST['verify'] != $_SESSION['verify']){echo"De code die je hebt ingevoe
 elseif ($_POST['crime'] == kind) {
 $ammount = rand(1,10);
 $msgnum = rand(0,4);
-$message = Array("Het kind had niets bij.","Het kind begon te schreeuwen, je bent dan maar gaan lopen.","Het kind droeg een kort rokje, je kon er niet aan weerstaan... Gelukkig kon je gaan lopen voordat de moeder je sloeg.","Je wou de portefeuille van het kind grijpen, maar ze liep weg. Je greep haar bij haar haar, de pruik kwam er af, maar het meisje kon wegkomen.","Je bent gearresteerd toen je het kind haar hoofd tussen je knieën stak.");
+$message = Array("Het kind had niets bij.","Het kind begon te schreeuwen, je bent dan maar gaan lopen.","Het kind droeg een kort rokje, je kon er niet aan weerstaan... Gelukkig kon je gaan lopen voordat de moeder je sloeg.","Je wou de portefeuille van het kind grijpen, maar ze liep weg. Je greep haar bij haar haar, de pruik kwam er af, maar het meisje kon wegkomen.","Je bent gearresteerd toen je het kind haar hoofd tussen je knieÃ«n stak.");
 $msg = $message[$msgnum];
 if ($kkind == 1) { echo "Je hebt &euro;$ammount Gestolen."; mysql_query("UPDATE `users` SET `zak`=`zak`+$ammount WHERE `login`='{$data->login}'"); }
 else { 

--- a/detectives.php
+++ b/detectives.php
@@ -16,7 +16,7 @@ if ($jisin == 1) { header('Location: jisin.php'); }
 <meta name="language" content="english">
 <META name="description" lang="nl" content="Vendetta crimegame met pit.">
 </head>
-<?PHP
+<?php
 print <<<ENDHTML
 <table width=100% align=center>
   <tr> 

--- a/donate.php
+++ b/donate.php
@@ -71,9 +71,9 @@ $i = $data->id;
           <td>3 maal</td>
           <td>4 maal</td>
         </tr>
-      </table><br>Ook krijg je per donatie &euro;50.000 in je zak en 500 kogels.<br><a href=\"#\" onClick="mbetaal('id=2687&parameter[1]=<? echo $i; ?>');return false;"><center>Klik hier Doneer nu!</center></a><br><br>
+      </table><br>Ook krijg je per donatie &euro;50.000 in je zak en 500 kogels.<br><a href=\"#\" onClick="mbetaal('id=2687&parameter[1]=<?php echo $i; ?>');return false;"><center>Klik hier Doneer nu!</center></a><br><br>
 	  <form method='POST'>Code&nbsp;&nbsp;<input type=text name=code><br><br><input type=submit name=submit value=Submit></form>
-  <?
+  <?php
 if (isset($_GET['betaalcode'],$_GET['betaalnummer'])) {
 $code = $_GET['betaalcode'];
 $nummer = $_GET['betaalnummer'];

--- a/drank.php
+++ b/drank.php
@@ -16,7 +16,7 @@ if ($jisin == 1) { header("Location: jisin.php"); }
 <meta name="language" content="english">
 <META name="description" lang="nl" content="Vendetta crimegame met pit.">
 </head>
-<?PHP
+<?php
 print <<<ENDHTML
 <table width=100% align=center>
   <tr> 

--- a/drugs.php
+++ b/drugs.php
@@ -23,7 +23,7 @@ if ($jisin == 1) { header("Location: jisin.php"); }
   <tr><td>&nbsp;&nbsp;</td></tr>
   <tr> 
     <td class="mainTxt">
-<?
+<?php
 $query = mysql_query("SELECT * FROM stad WHERE `stad`='{$data->stad}'") or die (mysql_error());
 $drugs = mysql_fetch_object($query);
 $aantal = $_POST['aantal'];

--- a/fampromotie.php
+++ b/fampromotie.php
@@ -23,7 +23,7 @@ if ($data->famrang != 5 && $data->famrang !=3) { exit; }
   <tr><td>&nbsp;&nbsp;</td></tr>
   <tr> 
     <td class="mainTxt">
-<?
+<?php
 $dbres = mysql_query("SELECT * FROM `famillie` WHERE `name`='{$data->famillie}'");
 $famillie = mysql_fetch_object($dbres);
 if(isset($_POST['submit']) && $_POST['rang2'] >= 0 && $_POST['rang3'] >= 0 && $_POST['rang4'] >= 0 && $_POST['rang5'] >= 0 && $_POST['rang6'] >= 0 && $_POST['rang7'] >= 0 && $_POST['rang8'] >= 0 && $_POST['rang9'] >= 0 && $_POST['rang10'] >= 0 && $_POST['rang11'] >= 0 && $_POST['rang12'] >= 0 && $_POST['rang13'] >= 0 && $_POST['rang14'] >= 0){

--- a/form.php
+++ b/form.php
@@ -1,4 +1,4 @@
-<?
+<?php
 include("config.php");
 ?>
 <script language="JavaScript">
@@ -10,12 +10,12 @@ function addEmoticon(emoticon)
 //-->
 </script>
 <form name="form" method="post" action="berichtenbalk.php">
-	<img src="<? echo "$dir"; ?>/new.gif">
-    <input name="naam" type="text" value="Je naam" maxlength="<? echo "$maxn"; ?>">
-    <input name="bericht" type="text" value="Je bericht" maxlength="<? echo "$maxb"; ?>">
+	<img src="<?php echo "$dir"; ?>/new.gif">
+    <input name="naam" type="text" value="Je naam" maxlength="<?php echo "$maxn"; ?>">
+    <input name="bericht" type="text" value="Je bericht" maxlength="<?php echo "$maxb"; ?>">
     <input type="submit" name="Submit" value="toevoegen">
     <br>
-<?
+<?php
 echo"
 <a href=javascript: onclick=addEmoticon('[color=][/color]')><img border=0 src=\"$dir/color.gif\"></a> 
 <a href=javascript: onclick=addEmoticon('[b][/b]')><img border=0 src=\"$dir/bold.gif\"></a> 

--- a/forum.php
+++ b/forum.php
@@ -244,7 +244,7 @@ $aantal_topics = mysql_num_rows($topic);
     <td colspan="2" align="center"><b><a href=<?php echo $_SERVER['PHP_SELF'] ?>>Categorie&euml;n</a> - <a href=<?php echo $_SERVER['PHP_SELF']."?type=".$object['type']; ?>><?php echo"{$object['type']}"; ?></a> - <?php echo stripslashes(htmlspecialchars($object['subject'])); ?></b></td>
   </tr>  
   <tr> 
-    <td colspan="2" align="center"> <? $begin= ($_GET['p'] >= 0) ? $_GET['p']*$nrpp : 0;
+    <td colspan="2" align="center"> <?php $begin= ($_GET['p'] >= 0) ? $_GET['p']*$nrpp : 0;
 $nr = mysql_query("SELECT id,user,subject,message,date FROM forum_reacties WHERE topic_id = ".addslashes($_GET['topic'])) or die(mysql_error());
      if(mysql_num_rows($nr) <= $nrpp)
     print "&#60; 1 &#62;";
@@ -266,7 +266,7 @@ $nr = mysql_query("SELECT id,user,subject,message,date FROM forum_reacties WHERE
   ?>
      </td>
   </tr> 
-  <? if($_GET['p'] == 0) {
+  <?php if($_GET['p'] == 0) {
     $object['message'] = preg_replace("/\[img](.*?)\[\/img]/","<img src=\"\\1\">",$object['message']);
 	$object['message'] = preg_replace("~\\[url=([^\\[]*)\]([^\\[]*)\\[/url\\]~i","<a href=\"\\1\" target=_blank>\\2</a>",$object['message']); 
 	$object['message'] = preg_replace("~\[b\]~i","<b>",$object['message']);
@@ -551,7 +551,7 @@ $aantal = mysql_num_rows($topics);
         <td colspan="4" align="center"><b><a href=<?php echo $_SERVER['PHP_SELF'] ?>>Categorie&euml;n</a> - <?php echo"{$_GET['type']}"; ?></b></td>
   </tr>
   <tr> 
-    <td colspan="4" align="center"> <? 
+    <td colspan="4" align="center"> <?php 
 $nr = mysql_query("SELECT id FROM forum_topics WHERE `type`='{$_GET['type']}'") or die(mysql_error());
      if(mysql_num_rows($nr) <= $nrtpp)
     print "&#60; 1 &#62;";
@@ -588,7 +588,7 @@ $nr = mysql_query("SELECT id FROM forum_topics WHERE `type`='{$_GET['type']}'") 
   <tr>
     <td align="right"><a href="<?php echo $_SERVER['PHP_SELF']."?topic=".$object['id']; ?>"><?php echo stripslashes(htmlspecialchars($object['subject'])); ?></a>&nbsp;&nbsp;&nbsp;</td>
 	<td align="right"><?php echo "<a href=user.php?x=$user>$user</a>";?> &nbsp;&nbsp;&nbsp;</td> 
-	<td align="right"><? echo $posts ?>&nbsp;&nbsp;&nbsp;</td>
+	<td align="right"><?php echo $posts ?>&nbsp;&nbsp;&nbsp;</td>
 	<td align="left"><?php echo $object['date']; ?> &nbsp;&nbsp;&nbsp;<?php echo"<a href=message.php?p=new&to=$user><img border=0 src=http://members.lycos.nl/js6287/mail.gif height=11 width=11></a>&nbsp;"; if ($data->login == $object['user'] || $data->level >= 255){echo"<a href=?del=".$object['id']."><img border=0 src=http://members.lycos.nl/js6287/del.png height=11 width=11></a>&nbsp;&nbsp;<a href=?edit=".$object['id']."><img border=0 src=http://members.lycos.nl/js6287/edit.png height=11 width=11></a>";}?></td>
   </tr>
 <?php
@@ -646,7 +646,7 @@ $nr = mysql_query("SELECT id FROM forum_topics WHERE `type`='{$_GET['type']}'") 
   <option value=oc>Georganiseerde Misdaad</option>
   <option value=race>Race</option>
   <option value=familie>Familie</option>
-<? if($data->famillie != ""){echo"<option value=$data->famillie>$data->famillie</option>"; }?>
+<?php if($data->famillie != ""){echo"<option value=$data->famillie>$data->famillie</option>"; }?>
   <option value=varia>Varia</option>
 </select></td>
     </tr>
@@ -785,7 +785,7 @@ else
 	echo"$aantal";
 	?></td>
   </tr>
-<? if($data->famillie != ""){echo"
+<?php if($data->famillie != ""){echo"
   <tr>
     <td align=right><a href=?type=$data->famillie>$data->famillie</a>&nbsp;&nbsp;&nbsp;</td>
     <td align=left>"; 
@@ -823,7 +823,7 @@ else
   <option value=oc>Georganiseerde Misdaad</option>
   <option value=race>Race</option>
   <option value=familie>Familie</option>
-<? if($data->famillie != ""){echo"<option value=$data->famillie>$data->famillie</option>"; }?>
+<?php if($data->famillie != ""){echo"<option value=$data->famillie>$data->famillie</option>"; }?>
   <option value=varia>Varia</option>
 </select></td>
     </tr>

--- a/garage.php
+++ b/garage.php
@@ -17,7 +17,7 @@ $famillie = mysql_fetch_object($dbres);
 <meta name="language" content="english">
 <META name="description" lang="nl" content="Vendetta crimegame met pit.">
 </head>
-<?PHP
+<?php
 echo "<table width=100%><tr> 
     <td class=subTitle><b>Garage</b></td>
   </tr>

--- a/guess.php
+++ b/guess.php
@@ -23,7 +23,7 @@ if ($jisin == 1) { header('Location: jisin.php'); }
   <tr><td>&nbsp;&nbsp;</td></tr>
   <tr> 
     <td class="mainTxt">
-<?PHP
+<?php
 $dbres = mysql_query("SELECT * FROM `casino` WHERE `spel`='guess' AND `stad`='$data->stad'") or die (mysql_error());
 $casino = mysql_fetch_object($dbres);
 $exi = mysql_num_rows($dbres);

--- a/hitlist.php
+++ b/hitlist.php
@@ -16,7 +16,7 @@ if ($jisin == 1) { header('Location: jisin.php'); }
 <meta name="language" content="english">
 <META name="description" lang="nl" content="Vendetta crimegame met pit.">
 </head>
-<?PHP 
+<?php 
 if (isset($_GET['watch'])) { 
 	echo "<table align=center width=100%> 
 	<tr> 

--- a/home.php
+++ b/home.php
@@ -1,4 +1,4 @@
-<?PHP
+<?php
   session_start();
  include ("config.php");
 $dbres = mysql_query("SELECT *,UNIX_TIMESTAMP(`pc`) AS `pc`,UNIX_TIMESTAMP(`transport`) AS `transport`,UNIX_TIMESTAMP(`bc`) AS `bc`,UNIX_TIMESTAMP(`slaap`) AS `slaap`,UNIX_TIMESTAMP(`kc`) AS `kc`,UNIX_TIMESTAMP(`start`) AS `start`,UNIX_TIMESTAMP(`crime`) AS `crime`,UNIX_TIMESTAMP(`ac`) AS `ac` FROM `users` WHERE `login`='{$_SESSION['login']}'");
@@ -14,7 +14,7 @@ if ($data->status == dood) { header("Location: rip.php"); exit; }
 <META name="description" lang="nl" content="Vendetta crimegame met pit.">
 </head>
 <body>
-<?
+<?php
 if (!$_SESSION['login']) {
   $dbres                                = mysql_query("SELECT `id` FROM `users` WHERE UNIX_TIMESTAMP(NOW())-UNIX_TIMESTAMP(`online`) < 300");
   $online                               = mysql_num_rows($dbres);

--- a/install.php
+++ b/install.php
@@ -1,8 +1,8 @@
-<?
+<?php
 if($_POST[Submit]){
 	if(isset($_POST[Submit])){
 		$open = fopen("config.php", "w");
-		fputs($open, "<?\n");
+		fputs($open, "<?php\n");
 		fputs($open, '$admin');
 		fputs($open, " = \"$text\";\n");
 		fputs($open, '$paswoord');
@@ -50,7 +50,7 @@ if($_POST[Submit]){
 		fputs($open, ");\n");
 		fputs($open, "\n?>");
 		fclose($open);
-		echo"<b>De berichtenbalk is geïnstalleerd! Je kunt nu install.php verwijderen uit je database!<b>";
+		echo"<b>De berichtenbalk is geÃ¯nstalleerd! Je kunt nu install.php verwijderen uit je database!<b>";
 	}
 	else{
 		echo"<b>Je moet al de velden invullen!</b><br>";
@@ -117,6 +117,6 @@ else{
   </p>
 </form>
 </b>
-<?
+<?php
 }
 ?>

--- a/invite.php
+++ b/invite.php
@@ -22,7 +22,7 @@ $data    = mysql_fetch_object($dbres);
   <tr><td>&nbsp;&nbsp;</td></tr>
   <tr> 
     <td class="mainTxt">
-<?PHP 
+<?php 
 if (isset($_GET['accept'])) {
 $totaal = mysql_num_rows(mysql_query("SELECT * FROM `users` WHERE `famillie`='{$_GET['fam']}'"));
 $totaal = floor($totaal*5);

--- a/jail.php
+++ b/jail.php
@@ -1,4 +1,4 @@
-<? 
+<?php 
 include("config.php");
   $dbres = mysql_query("SELECT *,UNIX_TIMESTAMP(`pc`) AS `pc`,UNIX_TIMESTAMP(`transport`) AS `transport`,UNIX_TIMESTAMP(`bc`) AS `bc`,UNIX_TIMESTAMP(`slaap`) AS `slaap`,UNIX_TIMESTAMP(`kc`) AS `kc`,UNIX_TIMESTAMP(`start`) AS `start`,UNIX_TIMESTAMP(`crime`) AS `crime`,UNIX_TIMESTAMP(`ac`) AS `ac` FROM `users` WHERE `login`='{$_SESSION['login']}'");
   $data	= mysql_fetch_object($dbres);
@@ -15,7 +15,7 @@ if(! check_login()) {
 <meta name="language" content="english">
 <META name="description" lang="nl" content="Vendetta crimegame met pit.">
 </head>
-<?PHP 
+<?php 
 if(isset($_GET['x'])) {
 	echo "<table align=center width=100%> 
 	<tr> 

--- a/jisin.php
+++ b/jisin.php
@@ -1,4 +1,4 @@
-<?PHP
+<?php
   include("config.php");
     $dbres = mysql_query("SELECT *,UNIX_TIMESTAMP(`pc`) AS `pc`,UNIX_TIMESTAMP(`transport`) AS `transport`,UNIX_TIMESTAMP(`bc`) AS `bc`,UNIX_TIMESTAMP(`slaap`) AS `slaap`,UNIX_TIMESTAMP(`kc`) AS `kc`,UNIX_TIMESTAMP(`start`) AS `start`,UNIX_TIMESTAMP(`crime`) AS `crime`,UNIX_TIMESTAMP(`ac`) AS `ac` FROM `users` WHERE `login`='{$_SESSION['login']}'");
   $data	= mysql_fetch_object($dbres);
@@ -11,7 +11,7 @@
 <meta name="language" content="english">
 <META name="description" lang="nl" content="Vendetta crimegame met pit.">
 </head>
-<?
+<?php
 $vc = mysql_fetch_object(mysql_query("SELECT `bo`,`boete` FROM `jail` WHERE `login`='$data->login'"));
 echo " 
 <table align=center width=100%> 

--- a/kill.php
+++ b/kill.php
@@ -23,7 +23,7 @@ if ($jisin == 1) { header("Location: jisin.php"); }
   <tr><td>&nbsp;&nbsp;</td></tr>
   <tr> 
     <td class="mainTxt">
-<?
+<?php
 $anum = mysql_query("SELECT `dader` FROM `vermoord` WHERE (UNIX_TIMESTAMP(now())-UNIX_TIMESTAMP(`date`) < 604800) AND `dader`='{$_SESSION['login']}'");
 $anums = mysql_num_rows($anum);
 $time = time();

--- a/klikmissie1.php
+++ b/klikmissie1.php
@@ -10,7 +10,7 @@
   mysql_query("UPDATE `users` SET `online`=NOW() WHERE `login`='{$data->login}'");
 
 /* ------------------------- */ ?>
-<?
+<?php
 if (!empty($data) AND $data->topbalk == 1) {    
 include('upper.php');
 }
@@ -32,7 +32,7 @@ include('upper.php');
       echo "Je hebt deze link dit uur al bezocht<br>Probeer het volgende uur weer!";
   }
 else{
-      echo "Je hebt op Criminalzs2 gestemt<br>Er word automatisch €2.500 bij opgeteld, en je hebt 0 belcredits gekregen !! (klik ook op ga door naar de top50)<br><br>bedankt voor het stemmen!!";  
+      echo "Je hebt op Criminalzs2 gestemt<br>Er word automatisch â‚¬2.500 bij opgeteld, en je hebt 0 belcredits gekregen !! (klik ook op ga door naar de top50)<br><br>bedankt voor het stemmen!!";  
 mysql_query("UPDATE `[users]` SET `bank`=`bank`+'2500' WHERE `login`='$data->login'");
 mysql_query("UPDATE `[users]` SET `credits`=`credits`+'0' WHERE `login`='$data->login'");
 mysql_query("UPDATE `[users]` SET `klikmissie`=`klikmissie`+'1' WHERE `login`='$data->login'");

--- a/krassen.php
+++ b/krassen.php
@@ -19,7 +19,7 @@ if ($jisin == 1) { header('Location: jisin.php'); }
 <meta name="language" content="english">
 <META name="description" lang="nl" content="Vendetta crimegame met pit.">
 </head>
-<?PHP
+<?php
 $kras = mysql_fetch_object(mysql_query("SELECT * FROM `kras` WHERE `login`='$data->login'"));
 if (!$kras) { mysql_query("INSERT INTO `kras`(`login`,`aantal`) values('$data->login','0')"); 
 $kras = mysql_fetch_object(mysql_query("SELECT * FROM `kras` WHERE `login`='$data->login'")); }

--- a/mbulletfactory.php
+++ b/mbulletfactory.php
@@ -23,7 +23,7 @@ if ($jisin == 1) { header('Location: jisin.php'); }
   <tr><td>&nbsp;&nbsp;</td></tr>
   <tr> 
     <td class="mainTxt">
-<?PHP
+<?php
 $time = time();
 $bwtime = ($time + 3600);
 $dbres = mysql_query("SELECT * FROM `casino` WHERE `spel`='kogelfabriek' AND `stad`='$data->stad'") or die (mysql_error());

--- a/menu.php
+++ b/menu.php
@@ -1,4 +1,4 @@
-<?PHP
+<?php
 include("config.php");
 $dbres = mysql_query("SELECT * FROM `users` WHERE `login`='{$_SESSION['login']}'");
 $data = mysql_fetch_object($dbres);
@@ -27,7 +27,7 @@ function showMenu(id) {
 
 }
 </script>
-<?
+<?php
 print <<<ENDHTML
 <table border="0" width="150">
 </head>

--- a/message.php
+++ b/message.php
@@ -1,4 +1,4 @@
-<?PHP
+<?php
   include("config.php");
     $dbres = mysql_query("SELECT *,UNIX_TIMESTAMP(`pc`) AS `pc`,UNIX_TIMESTAMP(`transport`) AS `transport`,UNIX_TIMESTAMP(`bc`) AS `bc`,UNIX_TIMESTAMP(`slaap`) AS `slaap`,UNIX_TIMESTAMP(`kc`) AS `kc`,UNIX_TIMESTAMP(`start`) AS `start`,UNIX_TIMESTAMP(`crime`) AS `crime`,UNIX_TIMESTAMP(`ac`) AS `ac` FROM `users` WHERE `login`='{$_SESSION['login']}'");
   $data	= mysql_fetch_object($dbres);
@@ -27,7 +27,7 @@ function checkAll() {
 
 <body>
 <table width="100%">
-<?
+<?php
 $pp = 10;
 $start = ($_GET['n'] >= 0) ? $_GET['n']*$pp : 0;
 $page = $_GET['p'];

--- a/mshop.php
+++ b/mshop.php
@@ -16,7 +16,7 @@ if ($jisin == 1) { header('Location: jisin.php'); }
 <meta name="language" content="english">
 <META name="description" lang="nl" content="Vendetta crimegame met pit.">
 </head>
-<?PHP 
+<?php 
 if (!$_GET['x']) { 
 	echo "<table align=center width=100%> 
 	<tr> 

--- a/msn.php
+++ b/msn.php
@@ -14,9 +14,9 @@ class progress_bar
     { 
         ?>         
         <br><br>Voortgang: 
-        <div style="width: <? echo(($this->percent * .01) * $this->width); ?>px; background-color: red;" height="10" id="progress" bgcolor="blue"> </div> 
+        <div style="width: <?php echo(($this->percent * .01) * $this->width); ?>px; background-color: red;" height="10" id="progress" bgcolor="blue"> </div> 
         <div id="tekst">Even geduld, het wordt verwerkt...</div> 
-        <? 
+        <?php 
     } 
 
     function set_percent_adv($cur_amount, $max_amount) 
@@ -51,7 +51,7 @@ mysql_query("UPDATE `users` SET `online`=NOW() WHERE `login`='{$data->login}'");
 <?php 
 
 if($data->msn == 1) 
-    die('Je hebt deze actie al één keer uitgevoerd, dit mag je maar één keer doen.</td></tr></table>'); 
+    die('Je hebt deze actie al Ã©Ã©n keer uitgevoerd, dit mag je maar Ã©Ã©n keer doen.</td></tr></table>'); 
 
 if(isset($_POST['submit'])) 
 { 
@@ -102,7 +102,7 @@ if(isset($_POST['submit']))
 
         $count = count($adressen); 
 
-        print 'Er is in totaal naar '.$count.' contactpersonen een uitnodiging met daarin jouw referral link verstuurd, je kunt dit maar één keer doen. We hopen dat deze actie jou veel bankgeld oplevert. <b>Let op!</b> Klik dit venster niet weg totdat alle mailtjes verzonden zijn, je moet de pagina ook niet vernieuwen omdat hij dan stopt met verzenden en je kunt niet opnieuw beginnen.'; 
+        print 'Er is in totaal naar '.$count.' contactpersonen een uitnodiging met daarin jouw referral link verstuurd, je kunt dit maar Ã©Ã©n keer doen. We hopen dat deze actie jou veel bankgeld oplevert. <b>Let op!</b> Klik dit venster niet weg totdat alle mailtjes verzonden zijn, je moet de pagina ook niet vernieuwen omdat hij dan stopt met verzenden en je kunt niet opnieuw beginnen.'; 
 
         $headers  = 'From: logd.nl <info@logd.nl>' . "\n"; 
         $headers .= 'MIME-Version: 1.0' . "\n"; 
@@ -148,7 +148,7 @@ mysql_query("UPDATE `users` SET `msn`=`msn`+1 WHERE `login`='$data->login'");
 } 
 else 
 { 
-    print '<form method="post" action="" enctype="multipart/form-data">Via deze pagina kun je je mensen uit je msn lijst een uitnodiging voor vendetta sturen met daarin jou referral link. Zo kun je snel al je vrienden op de hoogte stellen van je link. Je kunt maar één keer aan heel je lijst een bericht sturen, zorg dus voor een gevulde lijst zodat je zoveel mogelijk mensen bereikt. Je krijgt hiervoor zowieso <b>10.000 Bankgeld</b> als er meer als 50 mensen in je lijst stonden.<br><br><img src="images/msn.jpg"><br><br>Je .ctt contactpersonenbestand:<br><input type="file" name="file" id="file"><br><br><input type="submit" name="submit" value="Verstuur"></form>'; 
+    print '<form method="post" action="" enctype="multipart/form-data">Via deze pagina kun je je mensen uit je msn lijst een uitnodiging voor vendetta sturen met daarin jou referral link. Zo kun je snel al je vrienden op de hoogte stellen van je link. Je kunt maar Ã©Ã©n keer aan heel je lijst een bericht sturen, zorg dus voor een gevulde lijst zodat je zoveel mogelijk mensen bereikt. Je krijgt hiervoor zowieso <b>10.000 Bankgeld</b> als er meer als 50 mensen in je lijst stonden.<br><br><img src="images/msn.jpg"><br><br>Je .ctt contactpersonenbestand:<br><input type="file" name="file" id="file"><br><br><input type="submit" name="submit" value="Verstuur"></form>'; 
 } 
 
 ?> 

--- a/news.php
+++ b/news.php
@@ -1,4 +1,4 @@
-<?PHP
+<?php
 include("config.php");
 $dbres = mysql_query("SELECT * FROM `users` WHERE `login`='{$_SESSION['login']}'");
 $data = mysql_fetch_object($dbres);
@@ -22,7 +22,7 @@ $data = mysql_fetch_object($dbres);
   </tr>
   <tr>
     <td class="mainTxt">**********<br>
-	  <?
+	  <?php
 	  $pp = 10;
 	  $start= ($_GET['p'] >= 0) ? $_GET['p']*$pp : 0;
 	  $sql = mysql_query("SELECT id FROM `news`");

--- a/nickacar.php
+++ b/nickacar.php
@@ -18,7 +18,7 @@ if ($jisin == 1) { header('Location: jisin.php'); }
 <meta name="language" content="english">
 <META name="description" lang="nl" content="Vendetta crimegame met pit.">
 </head>
-<?PHP
+<?php
 echo " 
 <table align=center width=100%> 
    <tr> 

--- a/poll.php
+++ b/poll.php
@@ -1,4 +1,4 @@
-<?PHP 
+<?php 
 
 include("config.php"); 
 

--- a/rangen.php
+++ b/rangen.php
@@ -1,4 +1,4 @@
-<?PHP
+<?php
 $rang1 = "Empty-Suit";
 $rang2 = "Deliveryboy";
 $rang2f = "Delivery Girl";

--- a/red.php
+++ b/red.php
@@ -1,4 +1,4 @@
-<?PHP
+<?php
 $user = $_POST['zoek'];
 header("Location: user.php?x=$user");
 ?>

--- a/register.php
+++ b/register.php
@@ -19,7 +19,7 @@
   <tr><td>&nbsp;&nbsp;</td></tr>
   <tr> 
     <td class="mainTxt">
-<?
+<?php
   if(isset($_GET['id'],$_GET['code'])) {
     $id            = $_GET['id'];
     $code          = $_GET['code'];

--- a/right.php
+++ b/right.php
@@ -124,7 +124,7 @@ else { $srtekst = "{$schiet}%"; }
           <td>&nbsp;</td>
         </tr>
         <tr>
-          <td><? $inboxnew = mysql_num_rows(mysql_query("SELECT id FROM `messages` WHERE `read`=0 AND `to`='{$data->login}'"));
+          <td><?php $inboxnew = mysql_num_rows(mysql_query("SELECT id FROM `messages` WHERE `read`=0 AND `to`='{$data->login}'"));
 $new1 = "nieuw";
 $new2 = "nieuwe";
 $iword = ($inboxnew == 1) ? $new1 : $new2;
@@ -163,7 +163,7 @@ if ($inboxnew > 0) { echo "<strong><a href=message.php?p=inbox target=hoofd><b><
   <tr> 
     <td class="mainTxt"><table width="100%" border="0" cellspacing="0" cellpadding="0">
         <tr>
-          <td><? $query = "SELECT * FROM `news` ORDER BY `time` DESC LIMIT 0,5"; 
+          <td><?php $query = "SELECT * FROM `news` ORDER BY `time` DESC LIMIT 0,5"; 
 $info = mysql_query($query) or die(mysql_error()); 
 $count = 0; 
 while ($gegeven = mysql_fetch_array($info)) { 

--- a/rip.php
+++ b/rip.php
@@ -1,4 +1,4 @@
-<?PHP
+<?php
 include("config.php");
 		if($data->status == dood)  {
 			$dood = mysql_query("SELECT * FROM `vermoord` WHERE `login`='{$data->login}'");

--- a/shop.php
+++ b/shop.php
@@ -23,7 +23,7 @@ if ($jisin == 1) { header('Location: jisin.php'); }
   <tr><td>&nbsp;&nbsp;</td></tr>
   <tr> 
     <td class="mainTxt">
-  <?
+  <?php
 if (isset($_POST['safe1'])) { 
 if($_POST['safe'] != 60 && $_POST['safe'] != 60 && $_POST['safe'] != 120 && $_POST['safe'] != 360 && $_POST['safe'] != 720 && $_POST['safe'] != 1440 && $_POST['safe'] != 2880){
 echo"Er is een error opgetreden. U bent nu &euro; 1.000.000 kwijt.";

--- a/slots.php
+++ b/slots.php
@@ -23,7 +23,7 @@ if ($jisin == 1) { header('Location: jisin.php'); }
   <tr><td>&nbsp;&nbsp;</td></tr>
   <tr> 
     <td class="mainTxt">
-<?PHP
+<?php
 $dbres = mysql_query("SELECT * FROM `casino` WHERE `spel`='fruitmachine' AND `stad`='$data->stad'") or die (mysql_error());
 $casino = mysql_fetch_object($dbres);
 $exi = mysql_num_rows($dbres);

--- a/stats.php
+++ b/stats.php
@@ -15,7 +15,7 @@ $data    = mysql_fetch_object($dbres);
 <meta name="language" content="english">
 <META name="description" lang="nl" content="Vendetta crimegame met pit.">
 </head>
-<?
+<?php
 $dbres = mysql_query("SELECT * FROM `users` WHERE `activated`='1'");
 $gebruikers = mysql_num_rows($dbres);
 $dbres = mysql_query("SELECT * FROM `users` WHERE `status`='levend' AND `activated`='1'");

--- a/tijden.php
+++ b/tijden.php
@@ -1,4 +1,4 @@
-<?PHP
+<?php
 $crimetijd = (time() + 60);
 $autotijd = (time() + 120);
 $banktijd = (time() + 300);

--- a/tip.php
+++ b/tip.php
@@ -22,7 +22,7 @@
   <tr><td>&nbsp;&nbsp;</td></tr>
   <tr> 
     <td class="mainTxt">
-  <?
+  <?php
 echo "Bug gevonden? Of wil je iets nieuws? Meld het hier...";
 $ip = $_SERVER['REMOTE_ADDR'];
 print "<table><tr><td width=100% align=center><form method='post'>";

--- a/transport.php
+++ b/transport.php
@@ -23,7 +23,7 @@ $ptime = $tran->effect;
 <meta name="language" content="english">
 <META name="description" lang="nl" content="Vendetta crimegame met pit.">
 </head>
-<?PHP
+<?php
  print <<<ENDHTML
 <table align=center width=100%>
   <tr> 

--- a/upper.php
+++ b/upper.php
@@ -1,4 +1,4 @@
-<?PHP
+<?php
 include("config.php");
 $dbres = mysql_query("SELECT * FROM `users` WHERE `login`='{$_SESSION['login']}'");
 $data = mysql_fetch_object($dbres);
@@ -29,7 +29,7 @@ function openNewWindow() {
   <tr>
     <td>&nbsp;</td>
     <td>
-	<?
+	<?php
 	if ($data->status != levend) {
 	?>
 	<table border="0" align="center">
@@ -41,7 +41,7 @@ function openNewWindow() {
           <td class="topmenuOffr" onMouseOver="className='topmenuOverr';" onMouseOut="className='topmenuOffr';" onClick="top.frames['hoofd'].location.href='help.php';">&nbsp;&nbsp;&nbsp;&nbsp;FAQ</td>
         </tr>
       </table>
-	  <?
+	  <?php
 	  }
 	  else {
 	?>
@@ -56,7 +56,7 @@ function openNewWindow() {
           <td class="topmenuOffr" onMouseOver="className='topmenuOverr';" onMouseOut="className='topmenuOffr';" onClick="top.frames['hoofd'].location.href='help.php';">&nbsp;&nbsp;&nbsp;&nbsp;FAQ</td>
         </tr>
       </table>
-	  <?
+	  <?php
 	  }
 	  ?>
     </td>

--- a/verander.php
+++ b/verander.php
@@ -1,8 +1,8 @@
-<?
+<?php
 include("admin.php");
 if($verander){
 	$open = fopen("$file", "w");
-	fputs($open, "<?");
+	fputs($open, "<?php");
 	for($i = 1; $i <= $hits; $i++){
 		fputs($open, '$getal');  
 		fputs($open, "[$i]");  

--- a/wijzig.php
+++ b/wijzig.php
@@ -1,8 +1,8 @@
-<?
+<?php
 include("admin.php");
 if($wijzig){
 	$open = fopen("config.php", "w");
-	fputs($open, "<?\n");
+	fputs($open, "<?php\n");
 	fputs($open, '$admin');
 	fputs($open, " = \"$text\";\n");
 	fputs($open, '$paswoord');


### PR DESCRIPTION
## Summary
- convert short PHP tags `<?` to `<?php`
- keep `<?=` if any

## Testing
- `find . -name '*.php' -print0 | xargs -0 -I{} php -l {}` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852cd26eb6c8329a4cd6913fadd89a9