### PR TITLE
Fix session handling

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -5,8 +5,8 @@ $username = $HTTP_POST_VARS["username"];
 $password = $HTTP_POST_VARS["password"];  
 if($submit){
 	if ($username == "$admin" AND $password == "$paswoord") {  
-		$login = time();
-		session_register('login') ;
+                $login = time();
+                $_SESSION['login'] = $login;
 	} 
 	else{  
 		echo"<b>Je hebt een verkeerd paswoord of gebruikersnaam ingegeven!</b><br>";
@@ -25,9 +25,9 @@ if($_SESSION[login] + 60*60*24 > time()){
 	<input name="uitloggen" type="submit" value="Uitloggen">
 </form>
 <?
-	if($uitloggen){
-		session_unregister('login');
-	}
+        if($uitloggen){
+                unset($_SESSION['login']);
+        }
 	if($wissen){
 		if(!$bestand){
 			echo"<b>Er zijn nog geen berichten!</b><br>";

--- a/berichtenbalk.php
+++ b/berichtenbalk.php
@@ -25,8 +25,8 @@ if ($_POST[Submit]){
 		echo("<br><b>$ongeldig</b>");
 	}
 	elseif($_POST[naam] && $_POST[bericht]){
-		$tijd = time();  
-		session_register("tijd");  
+                $tijd = time();
+                $_SESSION['tijd'] = $tijd;
 		$open = fopen("$file", "a");  
 		fputs($open, "<?\n");  
 		fputs($open, '$getal');  

--- a/login.php
+++ b/login.php
@@ -17,10 +17,8 @@
 <table align="center" width=100%>
 <?php /* ------------------------- */
   if($_GET['x'] == "logout"){
-    session_unset($_SESSION['pass']);
-    session_destroy($_SESSION['login']);
-	session_unset($_SESSION['pass']);
-    session_destroy($_SESSION['login']);
+    unset($_SESSION['pass'], $_SESSION['login']);
+    session_destroy();
     echo"<table width=100% align=center>
 		   <tr><td class=subTitle><b>Uitloggen</b></td></tr>
 		   <tr><td>&nbsp;</td></tr>


### PR DESCRIPTION
## Summary
- replace old `session_register`/`session_unregister` calls with `$_SESSION`
- simplify redundant logout logic

## Testing
- `php -l admin.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852cd31758c83298fa2f8e4f3e0dcdd