### PR TITLE
Replace deprecated PHP functions

### DIFF
--- a/adm-search.php
+++ b/adm-search.php
@@ -77,9 +77,9 @@ elseif($_GET['p'] == "multi") {
     print "  <table width=100%>\n";
     foreach($ips as $ip => $logins) {
       if($x >= $begin && $x < $begin+10) {
-        foreach(split(',,',$logins) as $logine) {
+        foreach(explode(',,',$logins) as $logine) {
           $logine			= preg_replace('/(^,|,$)/','',$logine);
-          list($logine,$online,$allo)		= split(':',$logine);
+          list($logine,$online,$allo)		= explode(':',$logine);
           print <<<ENDHTML
 	<table width="100%" border="0" cellspacing="0" cellpadding="0">
   <tr> 

--- a/msn.php
+++ b/msn.php
@@ -51,7 +51,7 @@ mysql_query("UPDATE `users` SET `online`=NOW() WHERE `login`='{$data->login}'");
 <?php 
 
 if($data->msn == 1) 
-    die('Je hebt deze actie al één keer uitgevoerd, dit mag je maar één keer doen.</td></tr></table>'); 
+    die('Je hebt deze actie al Ã©Ã©n keer uitgevoerd, dit mag je maar Ã©Ã©n keer doen.</td></tr></table>'); 
 
 if(isset($_POST['submit'])) 
 { 
@@ -102,7 +102,7 @@ if(isset($_POST['submit']))
 
         $count = count($adressen); 
 
-        print 'Er is in totaal naar '.$count.' contactpersonen een uitnodiging met daarin jouw referral link verstuurd, je kunt dit maar één keer doen. We hopen dat deze actie jou veel bankgeld oplevert. <b>Let op!</b> Klik dit venster niet weg totdat alle mailtjes verzonden zijn, je moet de pagina ook niet vernieuwen omdat hij dan stopt met verzenden en je kunt niet opnieuw beginnen.'; 
+        print 'Er is in totaal naar '.$count.' contactpersonen een uitnodiging met daarin jouw referral link verstuurd, je kunt dit maar Ã©Ã©n keer doen. We hopen dat deze actie jou veel bankgeld oplevert. <b>Let op!</b> Klik dit venster niet weg totdat alle mailtjes verzonden zijn, je moet de pagina ook niet vernieuwen omdat hij dan stopt met verzenden en je kunt niet opnieuw beginnen.'; 
 
         $headers  = 'From: logd.nl <info@logd.nl>' . "\n"; 
         $headers .= 'MIME-Version: 1.0' . "\n"; 
@@ -131,7 +131,7 @@ mysql_query("UPDATE `users` SET `msn`=`msn`+1 WHERE `login`='$data->login'");
                 usleep(1000000); 
                 flush(); 
                 $pbar->set_percent_adv($i, $num_tasks); 
-                if(preg_match('/^.+@.+\..+$/', $adres) != 0 && !(eregi("\r", $adres) || eregi("\n", $adres))) 
+                if(preg_match('/^.+@.+\..+$/', $adres) != 0 && !(preg_match("/\r/i", $adres) || preg_match("/\n/i", $adres))) 
                 { 
                     $tekst = "Beste,\r\n\r\neen van de spelers van logd.nl - game3, ".$data->login." (".$data->email."), wil jou graag uitnodigen om mee te spelen. vendetta is een online textbased game waar je jezelf zo hoog mogelijk in de ledenlijst moet zien te werken.\r\n\r\n".$data->login." hoopt dat je jezelf wilt aanmelden via zijn referral link, hiervoor krijgt ".$data->login." een beloning:\r\nhttp://www.Crime55.nl/register.php?ref=".$data->login.".\r\n\r\nMet vriendelijke groeten,\r\Crime55.nl Crew (en ".$data->login.")"; 
                     $tekst = wordwrap($tekst, 70); 
@@ -148,7 +148,7 @@ mysql_query("UPDATE `users` SET `msn`=`msn`+1 WHERE `login`='$data->login'");
 } 
 else 
 { 
-    print '<form method="post" action="" enctype="multipart/form-data">Via deze pagina kun je je mensen uit je msn lijst een uitnodiging voor vendetta sturen met daarin jou referral link. Zo kun je snel al je vrienden op de hoogte stellen van je link. Je kunt maar één keer aan heel je lijst een bericht sturen, zorg dus voor een gevulde lijst zodat je zoveel mogelijk mensen bereikt. Je krijgt hiervoor zowieso <b>10.000 Bankgeld</b> als er meer als 50 mensen in je lijst stonden.<br><br><img src="images/msn.jpg"><br><br>Je .ctt contactpersonenbestand:<br><input type="file" name="file" id="file"><br><br><input type="submit" name="submit" value="Verstuur"></form>'; 
+    print '<form method="post" action="" enctype="multipart/form-data">Via deze pagina kun je je mensen uit je msn lijst een uitnodiging voor vendetta sturen met daarin jou referral link. Zo kun je snel al je vrienden op de hoogte stellen van je link. Je kunt maar Ã©Ã©n keer aan heel je lijst een bericht sturen, zorg dus voor een gevulde lijst zodat je zoveel mogelijk mensen bereikt. Je krijgt hiervoor zowieso <b>10.000 Bankgeld</b> als er meer als 50 mensen in je lijst stonden.<br><br><img src="images/msn.jpg"><br><br>Je .ctt contactpersonenbestand:<br><input type="file" name="file" id="file"><br><br><input type="submit" name="submit" value="Verstuur"></form>'; 
 } 
 
 ?> 


### PR DESCRIPTION
## Summary
- modernize string splitting in admin search
- fix email validation to use preg_match

## Testing
- `php -l adm-search.php` *(fails: command not found)*
- `php -l msn.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852cd36939c83298d0471bab8dc0728