### PR TITLE
Add CSRF token and secure session cookies

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -1,8 +1,7 @@
-<?php 
-session_start();
-include("config.php"); 
-$username = $_POST["username"];
-$password = $_POST["password"];
+<?php
+require 'config.php';
+$username = $_POST["username"] ?? '';
+$password = $_POST["password"] ?? '';
 if($submit){
 	if ($username == "$admin" AND $password == "$paswoord") {  
                 $login = time();
@@ -121,8 +120,9 @@ echo"<input name=verander type=submit value=Wijzigen>";
 }
 else{
 ?>  
-<form name="form1" method="post" action="<?php echo"$PHP_SELF"; ?>"><p>Gebruikersnaam: 
-    <input name="username" type="text" id="username">Paswoord: 
+<form name="form1" method="post" action="<?php echo"$PHP_SELF"; ?>"><p>Gebruikersnaam:
+    <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($_SESSION['csrf_token']); ?>">
+    <input name="username" type="text" id="username">Paswoord:
     <input name="password" type="password" id="password">      
     <input name="submit" type="submit" id="submit" value="Login"> 
 </form> 

--- a/config.php
+++ b/config.php
@@ -1,7 +1,23 @@
 <?php
 declare(strict_types=1);
 require_once __DIR__.'/pdo.php';
+// Configure secure session cookies
+$secure = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off');
+session_set_cookie_params(['httponly' => true, 'secure' => $secure]);
 session_start();
+
+// Generate a CSRF token for the session
+if (empty($_SESSION['csrf_token'])) {
+    $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
+}
+
+// Validate CSRF token on POST requests
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $postedToken = $_POST['csrf_token'] ?? '';
+    if (!hash_equals($_SESSION['csrf_token'], $postedToken)) {
+        die('Invalid CSRF token');
+    }
+}
 
 // Compatibility layer for old mysql_* functions using PDO
 function mysql_query(string $query) {

--- a/home.php
+++ b/home.php
@@ -1,6 +1,5 @@
 <?php
-  session_start();
- include ("config.php");
+require 'config.php';
 $dbres = mysql_query("SELECT *,UNIX_TIMESTAMP(`pc`) AS `pc`,UNIX_TIMESTAMP(`transport`) AS `transport`,UNIX_TIMESTAMP(`bc`) AS `bc`,UNIX_TIMESTAMP(`slaap`) AS `slaap`,UNIX_TIMESTAMP(`kc`) AS `kc`,UNIX_TIMESTAMP(`start`) AS `start`,UNIX_TIMESTAMP(`crime`) AS `crime`,UNIX_TIMESTAMP(`ac`) AS `ac` FROM `users` WHERE `login`='{$_SESSION['login']}'");
 $data	= mysql_fetch_object($dbres);
 if ($data->status == dood) { header("Location: rip.php"); exit; }

--- a/index.php
+++ b/index.php
@@ -1,6 +1,6 @@
 <?php
 declare(strict_types=1);
-session_start();
+require 'config.php';
 ?>
 <!DOCTYPE html>
 <html lang="nl">

--- a/login.php
+++ b/login.php
@@ -47,6 +47,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         <div class="alert alert-danger"><?= htmlspecialchars($error) ?></div>
     <?php endif; ?>
     <form method="post" class="mb-3">
+        <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($_SESSION['csrf_token']) ?>">
         <div class="mb-3">
             <label for="login" class="form-label">Gebruikersnaam</label>
             <input type="text" id="login" name="login" class="form-control" required>

--- a/register.php
+++ b/register.php
@@ -80,6 +80,7 @@ elseif(isset($_POST['submit'])) {
 $refer = $_GET['refer'];
  print <<<ENDHTML
    <form method="post">
+        <input type="hidden" name="csrf_token" value="{$_SESSION['csrf_token']}">
         <table width="100%">
           <tr> 
             <td width="49%"><div align="right">Login:</div></td>


### PR DESCRIPTION
## Summary
- enforce `secure` and `httponly` flags for session cookies
- generate a session CSRF token and validate it on POST requests
- include the CSRF token in login, register, and admin forms
- load `config.php` from index.php and home.php so token checks run

## Testing
- `php -l config.php`
- `php -l login.php`
- `php -l register.php`
- `php -l index.php`
- `php -l home.php`
- `php -l admin.php`


------
https://chatgpt.com/codex/tasks/task_e_687643eb1b988329a6eb3d446c4eb80a