### PR TITLE
Update README composer note

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,15 @@ This project is licensed under the MIT License. See [LICENSE](LICENSE) for detai
 
 PHPUnit tests live in the `tests/` directory. Install the development dependencies using Composer:
 
+
 ```bash
 composer install
 ```
+
+Composer downloads the development dependencies from Packagist. This step
+requires internet access unless you include the `vendor/` directory in the
+repository. Alternatively, you can pre-download the packages and commit the
+generated `composer.lock` file for reproducible installations.
 
 Run the tests with:
 


### PR DESCRIPTION
## Summary
- clarify that Composer needs internet access or a `vendor/` folder
- mention committing `composer.lock` for repeatable installs

## Testing
- `composer test` *(fails: phpunit not found)*

------
https://chatgpt.com/codex/tasks/task_e_687649c49b608329a5e1d7d22352c3ab