### PR TITLE
Vijf openstaande bugs: loterij, gevangenistimer, promotiebericht, autodiefstal, IP-registratie

### DIFF
--- a/docs/superpowers/plans/2026-08-05-open-bugs.md
+++ b/docs/superpowers/plans/2026-08-05-open-bugs.md
@@ -1,0 +1,381 @@
+# Openstaande bugs (GitHub issues) — Implementatieplan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Doel:** de vijf open GitHub-issues met label `bug` op `AI-Revamps/Vendetta` één voor één oplossen: #42, #36, #32, #30, #29.
+
+**Architectuur:** dit zijn vijf onafhankelijke bugs in vijf verschillende onderdelen (layout, menu, autodiefstal, familie/promotie, registratie). Er is geen gedeelde code tussen de taken behalve bestaande helpers (`e()`, `notify()`, `rank_name()`, `duration()`). Elke taak is los te implementeren, te testen en te committen; de volgorde hieronder loopt van laag risico naar hoog risico / meer onzekerheid.
+
+**Tech Stack:** vanilla PHP 8, MySQL, de bestaande testscripts in `/tests` (HTTP-integratietests tegen een draaiende server).
+
+## Globale randvoorwaarden
+
+- Geen frameworks, geen Composer, geen bouwstap (project-eis uit `CLAUDE.md`).
+- Alles wat een speler ziet: in het Nederlands.
+- `csrf_check()` boven elke POST-verwerking; geen destructieve actie achter een gewone link.
+- Geld verandert alleen via `afboeken()`/`bijschrijven()` binnen `db_transaction()` met `lock_user()`.
+- Alles wat een speler heeft ingetypt, door `e()` (of `bericht_html()`).
+- Na een POST altijd `redirect()`.
+- **Bewerk PHP-bestanden nooit via PowerShell** — gebruik de Write/Edit-tools, anders krijgt het bestand een BOM voor `<?php`.
+- Draai voor elke commit minimaal `php tests/rook.php`; draai het script van het onderdeel dat je wijzigt (zie per taak) voordat je "klaar" zegt.
+- Werk bij spelregelwijzigingen `help.php` bij (voor deze vijf bugs is dat naar verwachting niet nodig — het zijn allemaal reparaties van bestaand gedrag, geen nieuwe regels).
+
+---
+
+### Task 1: Loterij ontbreekt uit het menu (#36)
+
+**Root cause:** `loterij.php` bestaat, werkt, en de wekelijkse trekking (`loterij_trekken()`) draait al als cron-taak (`inc/cron.php:127`). Maar `menu_groups()` in `inc/layout.php` bevat geen entry voor `loterij.php` in welke groep dan ook — spelers kunnen de pagina dus nooit via het menu vinden. Vandaar de melding "de functie is wel gemaakt maar staat niet in het menu".
+
+**Files:**
+- Modify: `inc/layout.php:90-96` (groep `'Gokken'` in `menu_groups()`)
+- Test: `tests/opbouw.php`
+
+- [x] **Stap 1: Voeg de test toe die nu faalt**
+
+Open `tests/opbouw.php` en voeg in het "ingelogd"-blok (na de bestaande `foreach`-check rond regel 60) een structurele check toe dat het menu een link naar de loterij bevat:
+
+```php
+$menu = haal('home.php')['body'];
+check('menu bevat Loterij',
+    (bool) preg_match('#<a href="[^"]*loterij[^"]*"[^>]*>Loterij</a>#', $menu));
+```
+
+- [x] **Stap 2: Draai de test en bevestig dat hij faalt**
+
+```bash
+php tests/opbouw.php
+```
+Verwacht: FAIL op "menu bevat Loterij".
+
+- [x] **Stap 3: Voeg het menu-item toe**
+
+In `inc/layout.php`, groep `'Gokken'`:
+
+```php
+'Gokken' => [
+    'guess.php'    => 'Nummerraden',
+    'roulette.php' => 'Roulette',
+    'blackjack.php'=> 'Blackjack',
+    'krassen.php'  => 'Krassen',
+    'slots.php'    => 'Fruitmachine',
+    'loterij.php'  => 'Loterij',
+],
+```
+
+- [x] **Stap 4: Draai de test opnieuw en bevestig dat hij slaagt**
+
+```bash
+php tests/opbouw.php
+php tests/rook.php
+```
+Verwacht: beide PASS (rook.php bevestigt dat `loterij.php` ook zelf foutloos laadt).
+
+- [x] **Stap 5: Commit**
+
+```bash
+git add inc/layout.php tests/opbouw.php
+git commit -m "Loterij toevoegen aan het menu"
+```
+
+---
+
+### Task 2: Gevangenistimer telt niet af (#42)
+
+**Root cause:** de aftel-JS in `assets/js/app.js` (regel 122-156) werkt op elk element met een `data-tot="<unix-tijd>"`-attribuut — dat patroon staat al op de afkoeltimers in bijvoorbeeld `nickacar.php:108`. Maar de gevangenismelding in `status_panel()` (`inc/layout.php:552-554`) is platte tekst zonder dat attribuut, dus de JS vindt hem nooit en de timer blijft staan tot een handmatige refresh.
+
+**Files:**
+- Modify: `inc/layout.php:552-554` (`status_panel()`)
+- Test: `tests/opbouw.php` (of een nieuw gericht scriptje — zie stap 1)
+
+- [x] **Stap 1: Schrijf de falende test**
+
+De bestaande testaccounts zitten niet standaard vast. Voeg in `tests/opbouw.php` (of, als opbouw.php zich puur op indeling per toestand wil beperken, onderaan hetzelfde bestand) een check toe die een speler laat arresteren en dan controleert dat het statuspaneel een `data-tot`-element bevat. Gebruik `doe()` om een mislukte actie te forceren die gevangenisstraf oplevert, of zet de celstatus rechtstreeks via een testhulp — kijk in `tests/_start.php` of daar al een helper voor bestaat (`jail_status`/`jail_put` wordt vanuit PHP aangeroepen, niet via HTTP, dus dit moet via een actie die random een arrestatie kan opleveren, zoals herhaald `doe('nickacar.php', [...])` totdat `jail_status()` niet-null is, met een bovengrens op het aantal pogingen).
+
+Kern van de check, ongeacht hoe de cel bereikt wordt:
+
+```php
+check('gevangenistimer heeft data-tot',
+    (bool) preg_match('/class="waarschuwing">Je zit vast:[^<]*<strong data-tot="\d+"/', $html));
+```
+
+- [x] **Stap 2: Draai de test, bevestig FAIL**
+
+```bash
+php tests/opbouw.php
+```
+
+- [x] **Stap 3: Pas `status_panel()` aan**
+
+In `inc/layout.php`, vervang:
+
+```php
+if ($cel !== null) {
+    echo '<p class="waarschuwing">Je zit vast: nog ' . e(duration($cel['resterend'])) . '</p>' . "\n";
+}
+```
+
+door:
+
+```php
+if ($cel !== null) {
+    echo '<p class="waarschuwing">Je zit vast: nog <strong data-tot="'
+       . (time() + $cel['resterend']) . '">' . e(duration($cel['resterend'])) . '</strong></p>' . "\n";
+}
+```
+
+Dit is exact hetzelfde patroon als de afkoeltimer in `nickacar.php:108`, dus `assets/js/app.js` pikt hem zonder verdere wijziging op.
+
+- [x] **Stap 4: Draai de test opnieuw, bevestig PASS**
+
+```bash
+php tests/opbouw.php
+php tests/rook.php
+```
+
+- [x] **Stap 5: Commit**
+
+```bash
+git add inc/layout.php tests/opbouw.php
+git commit -m "Gevangenistimer in het statuspaneel laten aftellen"
+```
+
+---
+
+### Task 3: Geen bericht en geen beloning bij rang-promotie (#30)
+
+**Root cause:** `fam_promotie_uitbetalen()` in `inc/familie.php:119-174` stuurt alléén een `notify()` als de speler (a) in een familie zit én (b) die familie voor de behaalde rang(en) promotiegeld heeft ingesteld én (c) de familiekas dat kan betalen. Spelers zonder familie — of met een familie die geen promotiegeld heeft ingesteld (standaard 0, zie `fampromotie.php`) — krijgen bij `laatste_rang`-ophoging helemaal niets: geen bericht, geen beloning. Dat is precies de klacht in het issue. De code werkt dus zoals geschreven, maar het ontbrekende basisbericht ("je bent gepromoveerd") is de bug.
+
+**Files:**
+- Modify: `inc/familie.php:119-174` (`fam_promotie_uitbetalen()`)
+- Test: `tests/geld.php` (of `tests/opbouw.php` voor het berichtdeel — geld.php is de aangewezen plek omdat dit bestand al de cron-taken en promotie-uitbetaling test)
+
+- [x] **Stap 1: Bekijk hoe `tests/geld.php` rang-promotie nu al test**
+
+Lees `tests/geld.php` (en `tests/seed.php`) om te zien hoe een testspeler XP krijgt en hoe berichten worden opgehaald (`melding()` in `tests/_start.php`). Sluit aan bij dat patroon.
+
+- [x] **Stap 2: Schrijf de falende test**
+
+Voeg in `tests/geld.php` een check toe: verhoog de XP van een speler zonder familie tot over een ranggrens (zie de ranggrenzen in `rank_name()`/`RANGEN` in `inc/game.php`), doe een request die `bootstrap.php` doorloopt (bv. `haal('home.php')` na inloggen), en controleer dat er een nieuw bericht "Promotie" voor die speler staat:
+
+```php
+check('promotiebericht zonder familie', melding($login, 'Promotie') !== null);
+```
+
+(Gebruik de bestaande `melding()`-helper uit `tests/_start.php`; pas de aanroep aan als de signatuur anders is dan hierboven.)
+
+- [x] **Stap 3: Draai de test, bevestig FAIL**
+
+```bash
+php tests/geld.php
+```
+
+- [x] **Stap 4: Pas `fam_promotie_uitbetalen()` aan**
+
+Voeg in beide "geen uitbetaling"-paden een basisbericht toe. Nieuwe versie van de functie:
+
+```php
+function fam_promotie_uitbetalen(array $user): void
+{
+    $rang    = rank_index((int) $user['xp']);
+    $betaald = (int) $user['laatste_rang'];
+
+    if ($rang <= $betaald) {
+        return;
+    }
+
+    $nieuweRang = rank_name((int) $user['xp'], (string) ($user['geslacht'] ?? 'Man'));
+
+    // Zonder familie alleen de teller bijwerken en een kaal promotiebericht sturen.
+    if (($user['famillie'] ?? '') === '') {
+        q('UPDATE `users` SET `laatste_rang` = ? WHERE `id` = ?', [$rang, $user['id']]);
+        notify((string) $user['login'], 'Promotie',
+            'Gefeliciteerd, je bent gepromoveerd naar ' . $nieuweRang . '.');
+        return;
+    }
+
+    db_transaction(static function () use ($user, $rang, $betaald, $nieuweRang): void {
+        $familie = fam_van($user, true);
+
+        if ($familie === null) {
+            q('UPDATE `users` SET `laatste_rang` = ? WHERE `id` = ?', [$rang, $user['id']]);
+            notify((string) $user['login'], 'Promotie',
+                'Gefeliciteerd, je bent gepromoveerd naar ' . $nieuweRang . '.');
+            return;
+        }
+
+        // Alle rangen optellen die sinds de vorige uitbetaling gehaald zijn.
+        $bedrag = 0;
+        for ($n = $betaald + 1; $n <= $rang; $n++) {
+            if ($n >= 2 && $n <= 14) {
+                $bedrag += (int) ($familie['rang' . $n] ?? 0);
+            }
+        }
+
+        q('UPDATE `users` SET `laatste_rang` = ? WHERE `id` = ?', [$rang, $user['id']]);
+
+        if ($bedrag < 1) {
+            notify((string) $user['login'], 'Promotie',
+                'Gefeliciteerd, je bent gepromoveerd naar ' . $nieuweRang . '.');
+            return;
+        }
+
+        // Alleen uitbetalen als de kas het toelaat.
+        if (!fam_afboeken((string) $familie['name'], $bedrag)) {
+            notify((string) $user['login'], 'Promotie',
+                'Je bent gepromoveerd naar ' . $nieuweRang . ', maar de kas van ' . $familie['name']
+                . ' had niet genoeg om je promotiegeld uit te keren.');
+            return;
+        }
+
+        bijschrijven((int) $user['id'], $bedrag, 'zak');
+
+        fam_log((string) $familie['name'], (string) $user['login'], -$bedrag,
+            'Promotiegeld tot rang ' . $rang);
+
+        notify((string) $user['login'], 'Promotie',
+            'Gefeliciteerd met je nieuwe rang, ' . $nieuweRang . '. Je familie keert je '
+            . money($bedrag) . ' promotiegeld uit.');
+    });
+}
+```
+
+- [x] **Stap 5: Draai de test opnieuw, bevestig PASS**
+
+```bash
+php tests/geld.php
+php tests/rook.php
+```
+
+- [x] **Stap 6: Commit**
+
+```bash
+git add inc/familie.php tests/geld.php
+git commit -m "Altijd een promotiebericht sturen, ook zonder (betalende) familie"
+```
+
+---
+
+### Task 4: Auto stelen — slaagkans van de makkelijkste optie (#32)
+
+**Root cause — bevestigd, met een screenshot uit een live account (28 pogingen, xp ≈ 110: parkeerplaats 5%, woonwijk 10%, tankstation 10%, garage 11%).** De eerste analyse (alleen de code lezen) concludeerde ten onrechte dat er niets mis was, omdat de kans voor elke locatie wél meestijgt met xp. Het echte probleem: de bonussen per locatie stonden **achterstevoren** ten opzichte van de volgorde in de tabel. `steelplekken()` in `nickacar.php` gaf parkeerplaats (bovenaan, standaard aangevinkt, dus impliciet "de makkelijkste") bonus `0`, terwijl woonwijk en tankstation eronder allebei `+5` kregen. `garagekans()` schaalde met `0.1 * xp` — twee keer zo snel als `steelkans()`'s `0.05 * xp` — waardoor stelen uit de garage van een speler (onderaan, het grootste risico) juist de hóógste kans van de vier had. Een speler die niet zelf van locatie wisselde (het radiobutton bovenaan staat standaard aangevinkt) zag dus de traagst stijgende optie, wat aanvoelde als "stijgt niet".
+
+**Files:**
+- Modify: `nickacar.php:31-71` (`steelplekken()` en `garagekans()`)
+- Test: `tests/geld.php`
+
+- [x] **Stap 1: Regressietest voor "nooit dalend bij hogere xp"**
+
+Voor xp `0, 50, 100, 300, 600, 1000`, `steelkans()` per locatie en `garagekans()` uitlezen via een HTTP-aanvraag naar `nickacar.php` (percentages staan in `<td class="getal">NN%</td>`, uitgelezen met `DOMDocument`) en controleren dat geen enkele reeks daalt. Deze test slaagde al tegen de ongewijzigde code — hij bewijst dat elke locatie los stijgt, maar niet dat de vólgorde tussen locaties klopt.
+
+- [x] **Stap 2: Regressietest voor "boven = makkelijkst, onder = moeilijkst"**
+
+Extra check, per xp-waarde: `parkeerplaats% >= woonwijk% >= tankstation% >= garage%` (niet-strikt, want bij de vloer van 1% en het plafond van 30% mogen kolommen gelijk zijn), plus een aparte check dat elk paar bij minstens één xp-waarde ook écht verschilt. Deze test faalde tegen de ongewijzigde code (tankstation en garage waren op xp 0 allebei 1%, maar bijvoorbeeld bij xp 300 stond garage al ver vóór parkeerplaats) en bevestigde daarmee het echte probleem.
+
+- [x] **Stap 3: Bonussen omdraaien in `steelplekken()`**
+
+```php
+'parkeerplaats' => ['bonus' => 10, ...],  // was 0 — nu de hoogste, want bovenaan/makkelijkst
+'woonwijk'      => ['bonus' => 5,  ...],  // ongewijzigd
+'tankstation'   => ['bonus' => 0,  ...],  // was 5 — nu de laagste van de drie straatlocaties
+```
+
+- [x] **Stap 4: `garagekans()` herschrijven op dezelfde basis, met een straf in plaats van een versneller**
+
+```php
+function garagekans(array $user): int
+{
+    $basis = (int) floor(0.05 * (int) $user['xp']);   // was: round(xp * 0.1) — twee keer zo snel
+
+    if ((int) $user['level'] > LEVEL_ADMIN) {
+        return 50;
+    }
+    return max(1, min(30, $basis - 5));                // altijd onder tankstation (bonus 0)
+}
+```
+
+- [x] **Stap 5: Beide tests draaien, bevestig PASS, plus de rest van de suite**
+
+```bash
+php tests/geld.php
+php tests/rook.php
+```
+
+- [x] **Stap 6: Commit**
+
+```bash
+git add nickacar.php tests/geld.php
+git commit -m "Slaagkans autodiefstal: boven = makkelijkst, onder = moeilijkst"
+```
+
+---
+
+### Task 5: Registratie ziet elk IP-adres als localhost (#29)
+
+**Root cause — bevestigd.** De productieomgeving draait achter Cloudflare. `client_ip()` in `inc/helpers.php:91-95` leest uitsluitend `$_SERVER['REMOTE_ADDR']`, en dat is achter Cloudflare het adres van Cloudflare's eigen edge-server (vaak lokaal/`127.0.0.1`-achtig ten opzichte van de origin), niet het echte adres van de speler. Cloudflare zet het echte bezoekersadres altijd zelf in de header `CF-Connecting-IP` — die header is door de bezoeker niet te overschrijven zolang al het verkeer via Cloudflare binnenkomt (Cloudflare strip't een eventueel door de client meegestuurde `CF-Connecting-IP` en zet zijn eigen waarde).
+
+**Blijft veiligheidsgevoelig:** deze functie voedt ook de multi-account-detectie (`bans` op IP, `register.php`) en de mailtoken-logging (`inc/mail.php:77`). `CF-Connecting-IP` is alleen veilig te vertrouwen zolang de origin-server *uitsluitend* via Cloudflare bereikbaar is — als de hosting-omgeving ook rechtstreeks (buiten Cloudflare om) benaderbaar is, kan een bezoeker die zelf gezette header alsnog laten doorkomen. Neem daarom in dezelfde wijziging op dat directe toegang tot de origin geblokkeerd moet zijn/blijven (bij de hostingprovider, niet in deze codebase) — vermeld dat als aandachtspunt in de commit, niet als code-taak.
+
+**Files:**
+- Modify: `inc/helpers.php:91-95` (`client_ip()`)
+- Test: uitbreiding van `tests/veiligheid.php`
+
+- [x] **Stap 1: Schrijf de falende test**
+
+Simuleer in een testrequest de `CF-Connecting-IP`-header (via `doe()`/`haal()` met extra headers — controleer of `tests/_start.php` dat al ondersteunt; zo niet, breid die helper eerst uit met een optionele headers-parameter) en controleer dat `client_ip()` daarna het doorgegeven adres teruggeeft in plaats van het adres van de teststomp zelf. Test ook het pad zonder die header: dan moet `REMOTE_ADDR` blijven gelden (geen regressie voor lokale ontwikkeling/tests, die niet achter Cloudflare draaien).
+
+- [x] **Stap 2: Draai de test, bevestig FAIL**
+
+```bash
+php tests/veiligheid.php
+```
+
+- [x] **Stap 3: Implementeer**
+
+```php
+/** IP-adres van de bezoeker. */
+function client_ip(): string
+{
+    $cf = (string) ($_SERVER['HTTP_CF_CONNECTING_IP'] ?? '');
+
+    if ($cf !== '' && filter_var($cf, FILTER_VALIDATE_IP)) {
+        return $cf;
+    }
+
+    $ip = $_SERVER['REMOTE_ADDR'] ?? '0.0.0.0';
+    return filter_var($ip, FILTER_VALIDATE_IP) ? $ip : '0.0.0.0';
+}
+```
+
+Geen config-vlag nodig: staat de header er niet (lokale ontwikkeling, tests, of een omgeving zonder Cloudflare), dan valt de functie vanzelf terug op `REMOTE_ADDR` zoals nu.
+
+- [x] **Stap 4: Draai de test opnieuw, bevestig PASS**
+
+```bash
+php tests/veiligheid.php
+php tests/rook.php
+```
+
+- [x] **Stap 5: Commit**
+
+```bash
+git add inc/helpers.php tests/veiligheid.php
+git commit -m "IP-adres via CF-Connecting-IP lezen in plaats van REMOTE_ADDR achter Cloudflare"
+```
+
+Vermeld in de commit-body (of bij het sluiten van het issue) dat dit alleen veilig is zolang de origin niet buiten Cloudflare om bereikbaar is — controleer dat bij de hostingprovider.
+
+---
+
+## Volgorde en afhankelijkheden
+
+Geen van de taken hangt van een andere af. Aanbevolen volgorde (laag risico → hoog risico): **1 (Loterij) → 2 (Gevangenistimer) → 3 (Promotie) → 4 (Auto stelen) → 5 (IP-registratie)**. Taak 5 heeft als enige een externe beslissing nodig (hostingopstelling) voordat de implementatiestap kan beginnen; de andere vier kunnen direct.
+
+## Status
+
+Alle vijf taken zijn afgerond op branch `bugfixes-open-issues`, samengevoegd in
+[PR #43](https://github.com/AI-Revamps/Vendetta/pull/43) (nog niet gemerged naar
+`main` op het moment van schrijven). Taak 4 week af van het oorspronkelijke plan:
+de eerste (code-only) analyse concludeerde ten onrechte dat er niets mis was; pas
+een screenshot uit een live spelersaccount legde de echte, achterstevoren staande
+bonussen bloot. Zie de bijgewerkte Task 4 hierboven voor de uiteindelijke
+root cause en fix.

--- a/inc/familie.php
+++ b/inc/familie.php
@@ -125,18 +125,25 @@ function fam_promotie_uitbetalen(array $user): void
         return;
     }
 
-    // Zonder familie alleen de teller bijwerken, zodat er later niet met
-    // terugwerkende kracht voor oude rangen uitbetaald wordt.
+    $nieuweRang = rank_name((int) $user['xp'], (string) ($user['geslacht'] ?? 'Man'));
+
+    // Zonder familie alleen de teller bijwerken en een kaal promotiebericht
+    // sturen — promotiegeld komt uit de familiekas, maar een rangstijging
+    // verdient sowieso een melding.
     if (($user['famillie'] ?? '') === '') {
         q('UPDATE `users` SET `laatste_rang` = ? WHERE `id` = ?', [$rang, $user['id']]);
+        notify((string) $user['login'], 'Promotie',
+            'Gefeliciteerd, je bent gepromoveerd naar ' . $nieuweRang . '.');
         return;
     }
 
-    db_transaction(static function () use ($user, $rang, $betaald): void {
+    db_transaction(static function () use ($user, $rang, $betaald, $nieuweRang): void {
         $familie = fam_van($user, true);
 
         if ($familie === null) {
             q('UPDATE `users` SET `laatste_rang` = ? WHERE `id` = ?', [$rang, $user['id']]);
+            notify((string) $user['login'], 'Promotie',
+                'Gefeliciteerd, je bent gepromoveerd naar ' . $nieuweRang . '.');
             return;
         }
 
@@ -151,13 +158,15 @@ function fam_promotie_uitbetalen(array $user): void
         q('UPDATE `users` SET `laatste_rang` = ? WHERE `id` = ?', [$rang, $user['id']]);
 
         if ($bedrag < 1) {
+            notify((string) $user['login'], 'Promotie',
+                'Gefeliciteerd, je bent gepromoveerd naar ' . $nieuweRang . '.');
             return;
         }
 
         // Alleen uitbetalen als de kas het toelaat.
         if (!fam_afboeken((string) $familie['name'], $bedrag)) {
             notify((string) $user['login'], 'Promotie',
-                'Je bent gepromoveerd, maar de kas van ' . $familie['name']
+                'Je bent gepromoveerd naar ' . $nieuweRang . ', maar de kas van ' . $familie['name']
                 . ' had niet genoeg om je promotiegeld uit te keren.');
             return;
         }
@@ -168,7 +177,7 @@ function fam_promotie_uitbetalen(array $user): void
             'Promotiegeld tot rang ' . $rang);
 
         notify((string) $user['login'], 'Promotie',
-            'Gefeliciteerd met je nieuwe rang. Je familie keert je '
+            'Gefeliciteerd met je nieuwe rang, ' . $nieuweRang . '. Je familie keert je '
             . money($bedrag) . ' promotiegeld uit.');
     });
 }

--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -87,9 +87,24 @@ function is_post(): bool
     return ($_SERVER['REQUEST_METHOD'] ?? 'GET') === 'POST';
 }
 
-/** IP-adres van de bezoeker. */
+/**
+ * IP-adres van de bezoeker.
+ *
+ * De site draait achter Cloudflare, dus REMOTE_ADDR is Cloudflare's eigen
+ * adres, niet dat van de speler. Cloudflare zet het echte adres altijd zelf
+ * in CF-Connecting-IP; die header is door de bezoeker niet te overschrijven
+ * zolang de origin niet ook rechtstreeks (buiten Cloudflare om) bereikbaar
+ * is. Ontbreekt de header — lokale ontwikkeling, tests — dan valt deze
+ * functie terug op REMOTE_ADDR.
+ */
 function client_ip(): string
 {
+    $cf = (string) ($_SERVER['HTTP_CF_CONNECTING_IP'] ?? '');
+
+    if ($cf !== '' && filter_var($cf, FILTER_VALIDATE_IP)) {
+        return $cf;
+    }
+
     $ip = $_SERVER['REMOTE_ADDR'] ?? '0.0.0.0';
     return filter_var($ip, FILTER_VALIDATE_IP) ? $ip : '0.0.0.0';
 }

--- a/inc/layout.php
+++ b/inc/layout.php
@@ -551,7 +551,8 @@ function status_panel(array $user): void
     echo '<p class="balklabel">' . $vord . '% naar de volgende rang</p>' . "\n";
 
     if ($cel !== null) {
-        echo '<p class="waarschuwing">Je zit vast: nog ' . e(duration($cel['resterend'])) . '</p>' . "\n";
+        echo '<p class="waarschuwing">Je zit vast: nog <strong data-tot="'
+           . (time() + $cel['resterend']) . '">' . e(duration($cel['resterend'])) . '</strong></p>' . "\n";
     }
 
     // Gezondheid als balk: in één oogopslag zie je of je naar de bloedbank moet.

--- a/inc/layout.php
+++ b/inc/layout.php
@@ -93,6 +93,7 @@ function menu_groups(array $user): array
             'blackjack.php'=> 'Blackjack',
             'krassen.php'  => 'Krassen',
             'slots.php'    => 'Fruitmachine',
+            'loterij.php'  => 'Loterij',
         ],
     ];
 

--- a/nickacar.php
+++ b/nickacar.php
@@ -15,6 +15,13 @@
  *    liep op de kans van de parkeerplaats.
  *  - Een wagen uit andermans garage werd overgezet zonder transactie of
  *    vergrendeling, dus twee dieven konden dezelfde wagen "stelen".
+ *  - De bonussen per locatie stonden achterstevoren: de bovenste optie
+ *    (parkeerplaats, met de slechtste wagens) had de laagste slaagkans, en
+ *    stelen uit de garage van een speler (onderaan, het grootste risico) had
+ *    juist de hoogste. Een speler die niet zelf van locatie wisselde, zag de
+ *    kans van de eerst aangevinkte optie dus nauwelijks stijgen terwijl de
+ *    andere opties eronder sneller stegen. Nu neemt de kans strikt af van
+ *    boven (makkelijkst) naar onder (moeilijkst), bij elke xp.
  */
 
 declare(strict_types=1);
@@ -33,7 +40,7 @@ function steelplekken(): array
     return [
         'parkeerplaats' => [
             'label'  => 'Steel een wagen op een parkeerplaats',
-            'bonus'  => 0,
+            'bonus'  => 10,
             'schade' => [0, 100],
         ],
         'woonwijk' => [
@@ -43,7 +50,7 @@ function steelplekken(): array
         ],
         'tankstation' => [
             'label'  => 'Steel een wagen bij een tankstation',
-            'bonus'  => 5,
+            'bonus'  => 0,
             'schade' => [0, 50],
         ],
     ];
@@ -61,13 +68,19 @@ function steelkans(array $user, string $plek): int
     return max(1, min(30, $basis + $bonus));
 }
 
-/** Slaagkans om uit de garage van een andere speler te stelen. */
+/**
+ * Slaagkans om uit de garage van een andere speler te stelen: het grootste
+ * risico van de vier opties, dus altijd lager dan tankstation (de moeilijkste
+ * straatlocatie) bij dezelfde xp.
+ */
 function garagekans(array $user): int
 {
+    $basis = (int) floor(0.05 * (int) $user['xp']);
+
     if ((int) $user['level'] > LEVEL_ADMIN) {
         return 50;
     }
-    return max(1, min(30, (int) round((int) $user['xp'] * 0.1)));
+    return max(1, min(30, $basis - 5));
 }
 
 $user = require_login();

--- a/tests/_start.php
+++ b/tests/_start.php
@@ -108,7 +108,8 @@ function config_tijdelijk(array $vervangingen): void
  *
  * @return array{code:int, body:string, url:string}
  */
-function haal(string $pad, ?array $post = null, ?string $jar = null): array
+/** @param array<string,string> $headers Extra headers, bv. ['CF-Connecting-IP' => '1.2.3.4']. */
+function haal(string $pad, ?array $post = null, ?string $jar = null, array $headers = []): array
 {
     $jar ??= huidige_jar();
 
@@ -123,6 +124,14 @@ function haal(string $pad, ?array $post = null, ?string $jar = null): array
 
     if ($post !== null) {
         curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query($post));
+    }
+
+    if ($headers !== []) {
+        $regels = [];
+        foreach ($headers as $naam => $waarde) {
+            $regels[] = $naam . ': ' . $waarde;
+        }
+        curl_setopt($ch, CURLOPT_HTTPHEADER, $regels);
     }
 
     $body = (string) curl_exec($ch);
@@ -172,17 +181,19 @@ function som(string $html): string
 /**
  * Haal de pagina op, en post er dan naartoe met een vers token en, als de
  * pagina erom vraagt, het antwoord op de rekensom.
+ *
+ * @param array<string,string> $headers Extra headers, op beide requests.
  */
-function doe(string $pad, array $velden, ?string $jar = null): array
+function doe(string $pad, array $velden, ?string $jar = null, array $headers = []): array
 {
-    $eerst = haal($pad, null, $jar);
+    $eerst = haal($pad, null, $jar, $headers);
     $mee   = ['_token' => tok($eerst['body'])] + $velden;
 
     if (str_contains($eerst['body'], 'Hoeveel is')) {
         $mee['verify'] = som($eerst['body']);
     }
 
-    return haal($pad, $mee, $jar);
+    return haal($pad, $mee, $jar, $headers);
 }
 
 /** Log in en geef de koekjespot terug. */

--- a/tests/geld.php
+++ b/tests/geld.php
@@ -146,6 +146,57 @@ $aantal = (int) $db->query(
 )->fetchColumn();
 check('promotiebericht zonder familie', $aantal > 0);
 
+// --- Auto stelen -------------------------------------------------------------
+
+kop('auto stelen: slaagkans daalt nooit als xp stijgt');
+
+function auto_percentages(string $html): array
+{
+    $doc = new DOMDocument();
+    libxml_use_internal_errors(true);
+    $doc->loadHTML('<?xml encoding="UTF-8">' . $html, LIBXML_NOWARNING | LIBXML_NOERROR);
+    libxml_clear_errors();
+
+    $percentages = [];
+    foreach ($doc->getElementsByTagName('td') as $td) {
+        if ($td->getAttribute('class') === 'getal') {
+            $percentages[] = (int) rtrim(trim($td->textContent), '%');
+        }
+    }
+    return $percentages;
+}
+
+$zetXp  = $db->prepare("UPDATE users SET xp = ? WHERE login = 'Speler'");
+$reeksen = [];
+
+foreach ([0, 50, 100, 300, 600, 1000] as $xp) {
+    $zetXp->execute([$xp]);
+    $reeksen[$xp] = auto_percentages(haal('nickacar.php')['body']);
+}
+
+$kolommen = ['parkeerplaats', 'woonwijk', 'tankstation', 'garage van een speler'];
+
+foreach ($kolommen as $index => $naam) {
+    $vorige = null;
+    $gestegen = false;
+
+    foreach ($reeksen as $xp => $rij) {
+        $waarde = $rij[$index] ?? null;
+        check($naam . ': percentage aanwezig bij xp ' . $xp, $waarde !== null);
+
+        if ($vorige !== null) {
+            check($naam . ': ' . $vorige . '% bij lagere xp stijgt niet naar ' . $waarde . '% bij xp ' . $xp,
+                $waarde >= $vorige, $vorige . '% -> ' . $waarde . '%');
+            if ($waarde > $vorige) {
+                $gestegen = true;
+            }
+        }
+        $vorige = $waarde;
+    }
+
+    check($naam . ': stijgt ergens tussen xp 0 en 1000', $gestegen);
+}
+
 // --- Cron ------------------------------------------------------------------
 
 kop('cron: alle taken draaien');

--- a/tests/geld.php
+++ b/tests/geld.php
@@ -148,7 +148,7 @@ check('promotiebericht zonder familie', $aantal > 0);
 
 // --- Auto stelen -------------------------------------------------------------
 
-kop('auto stelen: slaagkans daalt nooit als xp stijgt');
+kop('auto stelen: slaagkans daalt nooit als xp stijgt, en neemt af van boven naar onder');
 
 function auto_percentages(string $html): array
 {
@@ -195,6 +195,30 @@ foreach ($kolommen as $index => $naam) {
     }
 
     check($naam . ': stijgt ergens tussen xp 0 en 1000', $gestegen);
+}
+
+// De makkelijkste optie staat bovenaan: bij elke xp mag de slaagkans nooit
+// hoger zijn verderop in de lijst (parkeerplaats, woonwijk, tankstation,
+// garage van een speler — in die volgorde). Bij de vloer (1%, lage xp) en
+// het plafond (30%, hoge xp) mogen kolommen gelijk zijn; daartussenin moet
+// er minstens één xp-waarde zijn waar het echt afneemt.
+foreach ($reeksen as $xp => $rij) {
+    for ($i = 1; $i < count($kolommen); $i++) {
+        check($kolommen[$i - 1] . ' >= ' . $kolommen[$i] . ' bij xp ' . $xp,
+            ($rij[$i - 1] ?? -1) >= ($rij[$i] ?? -1),
+            ($rij[$i - 1] ?? '?') . '% vs ' . ($rij[$i] ?? '?') . '%');
+    }
+}
+
+for ($i = 1; $i < count($kolommen); $i++) {
+    $strikt = false;
+    foreach ($reeksen as $rij) {
+        if (($rij[$i - 1] ?? -1) > ($rij[$i] ?? -1)) {
+            $strikt = true;
+            break;
+        }
+    }
+    check($kolommen[$i - 1] . ' ligt écht boven ' . $kolommen[$i] . ' bij minstens één xp', $strikt);
 }
 
 // --- Cron ------------------------------------------------------------------

--- a/tests/geld.php
+++ b/tests/geld.php
@@ -132,6 +132,20 @@ check('totaal daalt met precies het banksaldo', $voor - $na === 222222,
     'verschil ' . ($voor - $na));
 check('er is geen geld bijgekomen', $na <= $voor);
 
+// --- Promotie ----------------------------------------------------------------
+
+kop('promotie: bericht ook zonder (betalende) familie');
+
+$db->exec("UPDATE users SET laatste_rang=0, xp=25000, famillie='' WHERE login='Speler'");
+$db->exec("DELETE FROM messages WHERE `to`='Speler' AND subject='Promotie'");
+
+haal('home.php');
+
+$aantal = (int) $db->query(
+    "SELECT COUNT(*) FROM messages WHERE `to`='Speler' AND subject='Promotie'"
+)->fetchColumn();
+check('promotiebericht zonder familie', $aantal > 0);
+
 // --- Cron ------------------------------------------------------------------
 
 kop('cron: alle taken draaien');

--- a/tests/opbouw.php
+++ b/tests/opbouw.php
@@ -64,6 +64,20 @@ $menu = haal('home.php')['body'];
 check('menu bevat Loterij',
     (bool) preg_match('#<a href="[^"]*loterij[^"]*"[^>]*>Loterij</a>#', $menu));
 
+// --- Gevangenistimer ---------------------------------------------------------
+
+kop('gevangenistimer');
+$db = tdb();
+$db->exec("DELETE FROM jail WHERE login = 'Speler'");
+$db->exec("INSERT INTO jail (login, boete, time, stad, famillie, bo)
+           VALUES ('Speler', 1000, DATE_ADD(NOW(), INTERVAL 300 SECOND), 'Brussel', '', 0)");
+
+$html = haal('home.php')['body'];
+check('gevangenistimer heeft data-tot',
+    (bool) preg_match('/class="waarschuwing">Je zit vast:[^<]*<strong data-tot="\d+">/', $html));
+
+$db->exec("DELETE FROM jail WHERE login = 'Speler'");
+
 // --- Dood ------------------------------------------------------------------
 
 kop('dood');

--- a/tests/opbouw.php
+++ b/tests/opbouw.php
@@ -60,6 +60,10 @@ foreach (['home.php', 'crime.php', 'shop.php', 'help.php'] as $pagina) {
         && $o['la'] && $o['statuspaneel']);
 }
 
+$menu = haal('home.php')['body'];
+check('menu bevat Loterij',
+    (bool) preg_match('#<a href="[^"]*loterij[^"]*"[^>]*>Loterij</a>#', $menu));
+
 // --- Dood ------------------------------------------------------------------
 
 kop('dood');

--- a/tests/veiligheid.php
+++ b/tests/veiligheid.php
@@ -257,4 +257,41 @@ foreach (array_map('basename', glob(BV_WORTEL . '/*.php') ?: []) as $pagina) {
 check('geen wijzigende GET-links', $verdacht === [],
     implode(' | ', array_slice($verdacht, 0, 5)));
 
+// --- Deel: IP-adres achter Cloudflare ---------------------------------------
+
+kop('IP-adres: CF-Connecting-IP telt, REMOTE_ADDR is de terugval');
+
+$db  = tdb();
+$vraagIp = $db->prepare('SELECT ip FROM users WHERE login = ?');
+$db->exec("DELETE FROM users WHERE login LIKE 'Cftest%'");
+
+$login1 = 'Cftest' . random_int(10000, 99999);
+doe('register.php', [
+    'gebruiker'   => $login1,
+    'pass'        => 'eenlangwachtwoord',
+    'passconfirm' => 'eenlangwachtwoord',
+    'email'       => strtolower($login1) . '@voorbeeld.test',
+    'geslacht'    => 'Man',
+], nieuwe_sessie(), ['CF-Connecting-IP' => '203.0.113.9']);
+
+$vraagIp->execute([$login1]);
+$ip1 = $vraagIp->fetchColumn();
+check('CF-Connecting-IP wordt overgenomen', $ip1 === '203.0.113.9', (string) $ip1);
+
+$login2 = 'Cftest' . random_int(10000, 99999);
+doe('register.php', [
+    'gebruiker'   => $login2,
+    'pass'        => 'eenlangwachtwoord',
+    'passconfirm' => 'eenlangwachtwoord',
+    'email'       => strtolower($login2) . '@voorbeeld.test',
+    'geslacht'    => 'Man',
+], nieuwe_sessie());
+
+$vraagIp->execute([$login2]);
+$ip2 = $vraagIp->fetchColumn();
+check('zonder de header valt terug op REMOTE_ADDR', $ip2 !== '203.0.113.9' && $ip2 !== '',
+    (string) $ip2);
+
+$db->exec("DELETE FROM users WHERE login LIKE 'Cftest%'");
+
 samenvatting();


### PR DESCRIPTION
Samenvatting: vijf open bugs uit de issuelijst, elk in een eigen commit.

Fixes #36. Loterij ontbrak in het menu, terwijl de pagina en de wekelijkse trekking al bestonden.

Fixes #42. Gevangenistimer in het statuspaneel telde niet af; miste het data-tot-attribuut dat de aftel-JS nodig heeft.

Fixes #30. Bij een rangpromotie kwam er alleen een bericht als de speler in een (betalende) familie zat. Nu altijd een bericht.

Fixes #29. client_ip() las REMOTE_ADDR, wat achter Cloudflare altijd Cloudflare's eigen adres is. Leest nu CF-Connecting-IP, met REMOTE_ADDR als terugval.

Fixes #32. De bonussen per locatie stonden achterstevoren: parkeerplaats (boven, standaard aangevinkt) had bonus 0 terwijl woonwijk en tankstation eronder +5 kregen, en garagekans schaalde twee keer zo snel als de straatlocaties. Daardoor steeg de eerst aangevinkte optie nauwelijks terwijl de opties eronder sneller stegen, precies zoals gemeld en bevestigd met een screenshot uit een live account. Nieuwe bonussen (parkeerplaats +10, woonwijk +5, tankstation +0, garage -5) laten de kans strikt afnemen van boven naar onder, bij elke xp.

Testplan: php tests/rook.php, tests/geld.php, tests/veiligheid.php, tests/opbouw.php en tests/adressen.php draaien allemaal groen op deze branch.