### PR TITLE
Rijschool toevoegen aan het menu

### DIFF
--- a/inc/layout.php
+++ b/inc/layout.php
@@ -69,6 +69,7 @@ function menu_groups(array $user): array
             'bulletfactory.php'   => 'Kogelfabriek',
             'garage.php'          => 'Garage',
             'bloodbank.php'       => 'Bloedbank',
+            'rijbewijs.php'       => 'Rijschool',
             'transport.php'       => 'Transport',
             'detectives.php'      => 'Detectivebureau',
             'mshop.php'           => 'Zwarte markt',

--- a/tests/opbouw.php
+++ b/tests/opbouw.php
@@ -63,6 +63,8 @@ foreach (['home.php', 'crime.php', 'shop.php', 'help.php'] as $pagina) {
 $menu = haal('home.php')['body'];
 check('menu bevat Loterij',
     (bool) preg_match('#<a href="[^"]*loterij[^"]*"[^>]*>Loterij</a>#', $menu));
+check('menu bevat Rijschool',
+    (bool) preg_match('#<a href="[^"]*rijbewijs[^"]*"[^>]*>Rijschool</a>#', $menu));
 
 // --- Gevangenistimer ---------------------------------------------------------
 


### PR DESCRIPTION
rijbewijs.php en transport.php werken allebei correct, maar de rijschool zelf ontbrak in menu_groups() — precies dezelfde bug als bij de loterij (#36). De enige manier om er te komen was de link in transport.php's foutmelding als je nog geen rijbewijs hebt; zonder vervoermiddel of via een andere pagina was de rijschool onvindbaar. Fixes #39.

Testplan: php tests/rook.php, tests/geld.php, tests/veiligheid.php, tests/opbouw.php en tests/adressen.php draaien allemaal groen op deze branch.