### PR TITLE
Gratis huis, outgame-advertentie en veilige autoafbeeldingen

### DIFF
--- a/adm-premium.php
+++ b/adm-premium.php
@@ -67,12 +67,18 @@ echo '<span><label><input type="checkbox" id="captcha" name="captcha" value="1"'
    . (ads_captcha() ? ' checked' : '') . '> Speler moet een code overtypen voordat '
    . 'hij door kan</label></span>';
 
+echo '<label for="outgame">Ook op de voorpagina</label>';
+echo '<span><label><input type="checkbox" id="outgame" name="outgame" value="1"'
+   . (ads_outgame() ? ' checked' : '') . '> Dezelfde advertentiecode ook tonen aan '
+   . 'bezoekers die niet ingelogd zijn</label></span>';
+
 echo '<span></span><button type="submit">Opslaan</button>';
 echo '</div></form>';
 
 echo '<p class="uitleg">Op 0 zetten schakelt de advertentiepagina helemaal uit. Is het '
    . 'codeveld leeg, dan gebeurt er ook niets — spelers worden dan nooit onderbroken. '
-   . 'Premiumspelers krijgen de pagina nooit te zien.</p>';
+   . 'Premiumspelers krijgen de pagina nooit te zien. "Ook op de voorpagina" staat los van '
+   . 'het aantal pagina\'s hierboven: die teller bestaat pas na het inloggen.</p>';
 
 if (ads_html() !== '') {
     echo '<p><a class="knop" href="' . e(url('advertentie.php')) . '">Bekijk de pagina</a> '
@@ -207,6 +213,7 @@ function advertentie_opslaan(array $user): string
     instelling_zetten('ads_html', $html);
     instelling_zetten('ads_interval', (string) $interval);
     instelling_zetten('ads_captcha', post('captcha') === '1' ? '1' : '0');
+    instelling_zetten('ads_outgame', post('outgame') === '1' ? '1' : '0');
 
     log_action((string) $user['login'], 'premium',
         'Advertentie-instellingen gewijzigd (interval ' . $interval . ')');

--- a/help.php
+++ b/help.php
@@ -51,8 +51,8 @@ panel_close();
 panel_open('Hoe je begint', 'begin');
 
 echo '<p>Je begint als <strong>' . e(rank_name(0)) . '</strong> met '
-   . money((int) config('game.start_money', 1000)) . ' op zak, in een willekeurige stad, '
-   . 'en met een huis in die stad. Vanaf daar is het de bedoeling dat je opklimt tot '
+   . money((int) config('game.start_money', 1000)) . ' op zak, in een willekeurige stad. '
+   . 'Vanaf daar is het de bedoeling dat je opklimt tot '
    . '<strong>' . e(rank_name(999999)) . '</strong>.</p>';
 
 echo '<p>Dat doe je met misdaden, auto\'s stelen, overvallen, handel in drank en drugs, '
@@ -190,7 +190,7 @@ echo '<tr><td>een casino of kogelfabriek</td><td></td></tr>';
 echo '</tbody></table></div>';
 
 echo '<p>Je begint weer in een willekeurige stad met '
-   . money((int) config('game.start_money', 1000)) . ', een huis daar, en de '
+   . money((int) config('game.start_money', 1000)) . ', en de '
    . 'beginnersbescherming loopt opnieuw. Hoe vaak je omgelegd bent staat op je profiel.</p>';
 
 panel_close();

--- a/images/autos/LEESMIJ.md
+++ b/images/autos/LEESMIJ.md
@@ -1,0 +1,33 @@
+# Autoafbeeldingen
+
+Deze map hoort de foto's te bevatten die `install/schema.sql` voor de
+autocatalogus (tabel `cars`) verwacht. Het zijn beeldbestanden, geen code, dus
+ze staan niet in deze repository — voeg ze hier zelf toe.
+
+Nodig, exact deze bestandsnamen (kleine letters, zoals in `schema.sql`):
+
+```
+alfa_romeo_fnm_2000_jk.jpg
+aston_martin_db3s.jpg
+buick_cabrio.jpg
+caddillac_sedan.jpg
+chevy_camaro_ss.jpg
+chrysler_converible.jpg
+dodge_dart.jpg
+dodge_kingsway.jpg
+ford_fairlane.jpg
+ford_mustang.jpg
+mercury_cougar.jpg
+pontiac.jpg
+pontiac_bonneville.jpg
+porsche_356b_cabriolet.jpg
+streamliner.jpg
+```
+
+Ontbreekt een bestand, dan toont `nickacar.php` na een geslaagde autodiefstal
+gewoon geen plaatje — geen kapot plaatje-icoon. Zodra het bestand hier staat,
+verschijnt het vanzelf; er hoeft verder niets aangepast te worden.
+
+Wil je andere auto's of andere bestandsnamen? Pas dan de kolom `url` in de
+tabel `cars` aan (via `adm-items.php` of rechtstreeks in de database) zodat
+hij naar het juiste bestand in deze map wijst.

--- a/inc/game.php
+++ b/inc/game.php
@@ -404,11 +404,6 @@ function speler_herstarten(int $userId): string
         q('DELETE FROM `friends` WHERE `login` = ? OR `friend` = ?', [$naam, $naam]);
         q("UPDATE `casino` SET `owner` = '', `winst` = 0 WHERE `owner` = ?", [$naam]);
 
-        // Net als een nieuwe speler begin je met een huis in je startstad.
-        // Toen huisbezit nog een kolom per stad was viel dit buiten de reset,
-        // waardoor je na een doorstart je oude huizen gewoon hield.
-        huis_geven($naam, $stad);
-
         log_action($naam, 'herstart',
             'Opnieuw begonnen na overlijden nummer ' . ((int) $speler['gestorven'] + 1));
 

--- a/inc/premium.php
+++ b/inc/premium.php
@@ -67,6 +67,19 @@ function ads_html(): string
     return instelling('ads_html', '');
 }
 
+/**
+ * Moet dezelfde advertentiecode ook op de publieke voorpagina te zien zijn?
+ *
+ * Los van `ads_interval()`: die telt paginabezoeken van een ingelogde
+ * speler, en vóór het inloggen bestaat die teller niet. Sommige
+ * advertentienetwerken eisen dat hun code ook zichtbaar is voor bezoekers
+ * die niet ingelogd zijn, voordat ze een site goedkeuren.
+ */
+function ads_outgame(): bool
+{
+    return instelling('ads_outgame', '0') === '1';
+}
+
 // --- Premium ----------------------------------------------------------------
 
 /** Heeft deze speler op dit moment premium? */

--- a/index.php
+++ b/index.php
@@ -3,9 +3,35 @@
  * Voorpagina.
  *
  * Vervangt de oude frameset. Ingelogde spelers gaan meteen door naar hun status.
+ *
+ * Kan dezelfde advertentiecode tonen als advertentie.php (aan/uit op
+ * adm-premium.php), voor bezoekers die nog niet ingelogd zijn. Daarom krijgt
+ * ook deze pagina het ruimere beleid dat advertentienetwerken nodig hebben,
+ * ongeacht of de advertentie op dit moment aanstaat — dat weet je pas na het
+ * laden van inc/premium.php, en de header moet eerder verstuurd worden.
  */
 
 declare(strict_types=1);
+
+define('BV_ADVERTENTIEPAGINA', true);
+
+if (!headers_sent()) {
+    header('X-Content-Type-Options: nosniff');
+    header('Referrer-Policy: same-origin');
+    header('Content-Type: text/html; charset=utf-8');
+
+    header(
+        "Content-Security-Policy: "
+        . "default-src 'self' https:; "
+        . "script-src 'self' 'unsafe-inline' https:; "
+        . "style-src 'self' 'unsafe-inline' https:; "
+        . "img-src 'self' data: https: http:; "
+        . "frame-src https:; "
+        . "form-action 'self'; "
+        . "frame-ancestors 'self'; "
+        . "base-uri 'self'"
+    );
+}
 
 require __DIR__ . '/inc/bootstrap.php';
 
@@ -61,4 +87,13 @@ binnen.</p>
 </p>
 <?php
 panel_close();
+
+if (ads_outgame() && ads_html() !== '') {
+    panel_open('Advertentie');
+    // Bewust niet ge-escaped, net als op advertentie.php: dit is HTML die de
+    // beheerder zelf heeft ingeplakt om een advertentienetwerk te laten werken.
+    echo '<div class="advertentie">' . ads_html() . '</div>';
+    panel_close();
+}
+
 layout_footer();

--- a/install/schema.sql
+++ b/install/schema.sql
@@ -679,7 +679,7 @@ INSERT IGNORE INTO `cars` (`auto`, `naam`, `url`, `waarde`) VALUES
   ('Mercury Cougar',               'Mercury Cougar',                'images/autos/mercury_cougar.jpg',           95000),
   ('Chevy Camaro SS',              'Chevy Camaro SS',               'images/autos/chevy_camaro_ss.jpg',         125000),
   ('Ford Mustang',                 'Ford Mustang',                  'images/autos/ford_mustang.jpg',            150000),
-  ('Alfa Romeo FNM 2000 JK',       'Alfa Romeo FNM 2000 JK',        'images/autos/alfa_romeo _fnm_2000_jk.jpg', 175000),
+  ('Alfa Romeo FNM 2000 JK',       'Alfa Romeo FNM 2000 JK',        'images/autos/alfa_romeo_fnm_2000_jk.jpg',  175000),
   ('Porsche 356B Cabriolet',       'Porsche 356B Cabriolet',        'images/autos/porsche_356b_cabriolet.jpg',  200000),
   ('Mercedes W124 Avus Streamling','Mercedes W124 Avus Streamling', 'images/autos/streamliner.jpg',             400000);
 

--- a/nickacar.php
+++ b/nickacar.php
@@ -109,8 +109,13 @@ layout_header('Auto stelen');
 if ($uitkomst !== null) {
     notice(e($uitkomst['tekst']), $uitkomst['type']);
 
-    if (($uitkomst['auto'] ?? null) !== null && ($uitkomst['auto']['url'] ?? '') !== '') {
-        echo '<p><img src="' . e((string) $uitkomst['auto']['url']) . '" alt="'
+    $autoPad = (string) ($uitkomst['auto']['url'] ?? '');
+
+    // Alleen tonen als het bestand er ook echt staat: de catalogus (cars.url)
+    // verwijst naar foto's die niet allemaal aangeleverd zijn, en een kapot
+    // plaatje-icoon oogt slordiger dan gewoon niets tonen.
+    if ($autoPad !== '' && is_file(BV_ROOT . '/' . $autoPad)) {
+        echo '<p><img src="' . e(url($autoPad)) . '" alt="'
            . e((string) $uitkomst['auto']['auto']) . '" style="max-width:100%;border-radius:4px"></p>';
     }
 }

--- a/register.php
+++ b/register.php
@@ -133,8 +133,6 @@ function aanmelden(array $in): string
                 (int) config('game.start_money', 1000),
             ]
         );
-        // Je begint met een huis in je startstad; dat geeft daar thuisvoordeel.
-        huis_geven($login, $stad);
     });
 
     if (!$activatieNodig) {

--- a/tests/geld.php
+++ b/tests/geld.php
@@ -253,6 +253,29 @@ for ($i = 1; $i < count($kolommen); $i++) {
     check($kolommen[$i - 1] . ' ligt écht boven ' . $kolommen[$i] . ' bij minstens één xp', $strikt);
 }
 
+// --- Autoafbeeldingen ---------------------------------------------------------
+
+kop('auto stelen: geen kapot plaatje als de afbeelding ontbreekt');
+
+// Level boven LEVEL_ADMIN geeft een vaste slaagkans van 50%, zodat een
+// geslaagde diefstal binnen een paar pogingen gegarandeerd is. De afkoeltijd
+// wordt voor elke poging losgelaten: op de testserver hoeft niet echt
+// gewacht te worden.
+$db->exec("UPDATE users SET level=1000 WHERE login='Speler'");
+
+$gelukt = false;
+for ($poging = 0; $poging < 20 && !$gelukt; $poging++) {
+    $db->exec("UPDATE users SET ac=NULL WHERE login='Speler'");
+    $r = doe('nickacar.php', ['waar' => 'parkeerplaats']);
+    $gelukt = str_contains(melding($r['body']), '[ok]') && str_contains($r['body'], 'gestolen');
+}
+
+check('een autodiefstal is gelukt binnen 20 pogingen', $gelukt);
+check('geen kapot plaatje-icoon: geen <img> naar images/autos zonder dat het bestand bestaat',
+    !preg_match('#<img src="[^"]*images/autos/[^"]*"#', $r['body']), $r['body']);
+
+$db->exec("UPDATE users SET level=1 WHERE login='Speler'");
+
 // --- Cron ------------------------------------------------------------------
 
 kop('cron: alle taken draaien');

--- a/tests/geld.php
+++ b/tests/geld.php
@@ -132,6 +132,38 @@ check('totaal daalt met precies het banksaldo', $voor - $na === 222222,
     'verschil ' . ($voor - $na));
 check('er is geen geld bijgekomen', $na <= $voor);
 
+// --- Huis --------------------------------------------------------------------
+
+kop('huis: geen gratis huis bij registratie of herstart');
+
+$vraagHuizen = $db->prepare('SELECT COUNT(*) FROM huizen WHERE login = ?');
+
+// Registratie: een gloednieuwe speler krijgt geen huis cadeau dat meteen
+// weer verkocht kan worden voor gratis startgeld.
+$nieuweLogin = 'Huistest' . random_int(10000, 99999);
+doe('register.php', [
+    'gebruiker'   => $nieuweLogin,
+    'pass'        => 'eenlangwachtwoord',
+    'passconfirm' => 'eenlangwachtwoord',
+    'email'       => strtolower($nieuweLogin) . '@voorbeeld.test',
+    'geslacht'    => 'Man',
+], nieuwe_sessie());
+
+$vraagHuizen->execute([$nieuweLogin]);
+check('nieuwe speler krijgt geen gratis huis', (int) $vraagHuizen->fetchColumn() === 0);
+
+// Herstart na overlijden: Doelwit is hierboven vermoord. Diezelfde truc mag
+// niet herhaalbaar zijn door telkens dood te gaan en opnieuw te beginnen.
+$doelwitJar = login('Doelwit', 'eenlangwachtwoord');
+doe('rip.php', [], $doelwitJar);
+
+$vraagHuizen->execute(['Doelwit']);
+check('herstart na overlijden geeft geen gratis huis', (int) $vraagHuizen->fetchColumn() === 0);
+
+// Registreren en inloggen als Doelwit hebben de gedeelde standaardsessie
+// verlegd; de tests hierna verwachten weer Speler als ingelogde speler.
+login('Speler', 'eenlangwachtwoord');
+
 // --- Promotie ----------------------------------------------------------------
 
 kop('promotie: bericht ook zonder (betalende) familie');

--- a/tests/opbouw.php
+++ b/tests/opbouw.php
@@ -46,6 +46,37 @@ foreach (['index.php', 'help.php', 'login.php', 'register.php'] as $pagina) {
     check($pagina . ': wel een hamburger met menu', $o['hamburger'] && $o['la']);
 }
 
+// --- Advertentie op de voorpagina --------------------------------------------
+
+kop('advertentie op de voorpagina, alleen als hij aanstaat');
+
+$uit = haal('index.php', null, nieuwe_sessie())['body'];
+check('standaard geen advertentieblok op de voorpagina',
+    !str_contains($uit, 'class="advertentie"'));
+
+$baas = login('Baas', 'baaswachtwoord12345');
+doe('adm-premium.php', [
+    'actie'    => 'advertentie',
+    'html'     => '<div id="testadvertentie">Test-advertentie</div>',
+    'interval' => '25',
+    'outgame'  => '1',
+], $baas);
+
+$aan = haal('index.php', null, nieuwe_sessie())['body'];
+check('advertentieblok verschijnt als de instelling aanstaat',
+    str_contains($aan, 'class="advertentie"')
+        && str_contains($aan, '<div id="testadvertentie">Test-advertentie</div>'));
+
+// Instelling weer uitzetten, anders draait elke volgende pagina met reclame.
+doe('adm-premium.php', [
+    'actie'    => 'advertentie',
+    'html'     => '',
+    'interval' => '25',
+], $baas);
+
+$weerUit = haal('index.php', null, nieuwe_sessie())['body'];
+check('advertentieblok weg na uitzetten', !str_contains($weerUit, 'class="advertentie"'));
+
 // --- Ingelogd --------------------------------------------------------------
 
 kop('ingelogd');


### PR DESCRIPTION
Samenvatting: drie losse issues, elk in een eigen commit.

Fixes #34. Elke nieuwe speler kreeg via huis_geven() automatisch een gratis huis, en herstart na overlijden gaf er opnieuw een. Een huis kost 850.000 maar levert 750.000 op bij verkoop, dus was dit een herhaalbare gratis-geld-exploit (sterven, herstarten, verkopen, herhalen). Spelers kopen voortaan zelf hun eerste huis.

Fixes #40. Het bestaande advertentiesysteem (inc/premium.php) onderbrak alleen ingelogde spelers zonder premium. Nieuwe instelling ads_outgame (adm-premium.php) toont dezelfde advertentiecode nu ook op de publieke voorpagina, met hetzelfde ruimere Content-Security-Policy-beleid dat advertentienetwerken nodig hebben. Staat uit standaard.

Fixes #41. install/schema.sql verwijst voor de autocatalogus naar images/autos/, een map die nergens in de repo bestaat (het zijn foto's, geen code). nickacar.php toonde na een geslaagde diefstal altijd een img-tag, ook zonder dat bestand, wat een kapot plaatje-icoon gaf. Nu wordt eerst met is_file() gecontroleerd of de afbeelding er echt is. images/autos/LEESMIJ.md legt uit welke 15 bestanden verwacht worden. Ook een typefout in de bestandsnaam van de Alfa Romeo rechtgezet.

Testplan: php tests/rook.php, tests/geld.php, tests/veiligheid.php, tests/opbouw.php en tests/adressen.php draaien allemaal groen op deze branch.