### PR TITLE
Wapeneffect: hoger is beter, net als bescherming

### DIFF
--- a/adm-items.php
+++ b/adm-items.php
@@ -91,8 +91,9 @@ foreach (itemsoorten() as $soort => $label) {
     panel_close();
 }
 
-echo '<p class="uitleg">Bij wapens is een lager effect beter: het staat in de noemer van de '
-   . 'trefzekerheid. Bij vervoer is het effect de reistijd in seconden.</p>';
+echo '<p class="uitleg">Bij wapens en bescherming is een hoger effect beter: het is een '
+   . 'vermenigvuldiger op respectievelijk trefzekerheid en weerstand. Bij vervoer is het '
+   . 'effect de reistijd in seconden — daar is lager beter.</p>';
 
 layout_footer();
 

--- a/inc/combat.php
+++ b/inc/combat.php
@@ -70,9 +70,10 @@ function weerstand(array $speler, string $stad): float
 }
 
 /**
- * Trefzekerheid van de schutter: moordervaring gedeeld door het wapen.
+ * Trefzekerheid van de schutter: moordervaring keer het wapen.
  *
- * LET OP - hier is bewust van het origineel afgeweken.
+ * LET OP - hier is bewust van het origineel afgeweken, en dit is een tweede
+ * keer aangepast na de eerste herbouw.
  *
  * De oude formule was `100 / (weerstand * rand * aim) * kogels`. Daarin zat de
  * trefzekerheid in de noemer, waardoor méér moordervaring juist mínder schade
@@ -80,15 +81,23 @@ function weerstand(array $speler, string $stad): float
  * PHP 5 gaf dat oneindig veel schade (elke beginner doodde in één keer), op
  * PHP 8 is het een fatale fout.
  *
- * Hier telt trefzekerheid als vermenigvuldiger en zit er een ondergrens in.
- * Wil je de balans anders, pas dan de constanten bovenaan dit bestand aan.
+ * De eerste herbouw loste dat op door te delen door het wapen-effect in
+ * plaats van erdoor. Dat werkte, maar wapens in `items` kregen daardoor een
+ * *lager* effect naarmate ze duurder waren (zie install/schema.sql) — het
+ * omgekeerde van bescherming, waar een hoger effect een betere vest is. Op
+ * dezelfde winkelpagina las de kolom "Effect" dus twee kanten op. Nu telt het
+ * wapen-effect als vermenigvuldiger, net als bescherming: hoger is beter, en
+ * de waarden in `items` zijn dienovereenkomstig herzien.
+ *
+ * Wil je de balans anders, pas dan de constanten bovenaan dit bestand aan, of
+ * de effectwaarden van de wapens via adm-items.php.
  */
 function trefzekerheid(array $speler): float
 {
     $ervaring = max(GEVECHT_MIN_AIM, (float) $speler['se'] / 100);
     $wapen    = item_effect('att', (int) $speler['wapon']);
 
-    return $ervaring / $wapen;
+    return $ervaring * $wapen;
 }
 
 /**

--- a/install/schema.sql
+++ b/install/schema.sql
@@ -645,16 +645,16 @@ INSERT IGNORE INTO `stad` (`stad`, `kogels`, `prijs`, `drugs`, `drank`, `drugsp`
   ('Enschede',  100, 1273, 544,   0, 10080, 2803, 4500, 1000);
 
 INSERT IGNORE INTO `items` (`id`, `nr`, `type`, `naam`, `aprijs`, `vprijs`, `effect`) VALUES
-  (1,  1, 'att',   'Uzi',               25000,   20000,    3.00),
+  (1,  1, 'att',   'Uzi',               25000,   20000,    1.60),
   (2,  2, 'att',   'M16',               50000,   40000,    2.00),
   (3,  1, 'trans', 'Treinabonnement',  250000,  200000, 3600.00),
   (4,  3, 'trans', 'Limousine',       1000000,  750000, 1800.00),
-  (7,  4, 'att',   'Sniper Rifle',     100000,   80000,    1.50),
+  (7,  4, 'att',   'Sniper Rifle',     100000,   80000,    3.20),
   (8,  2, 'trans', 'Taxi',             750000,  600000, 2400.00),
-  (9,  3, 'att',   '9mm',               10000,    8000,    4.00),
+  (9,  3, 'att',   '9mm',               10000,    8000,    1.20),
   (10, 4, 'trans', 'Privé-Jet',       1500000, 1200000,  900.00),
-  (13, 6, 'att',   'Tommy Gun',        140000,  120000,    2.00),
-  (14, 5, 'att',   'Magnum Semi Auto',  75000,   60000,    1.99),
+  (13, 6, 'att',   'Tommy Gun',        140000,  120000,    4.20),
+  (14, 5, 'att',   'Magnum Semi Auto',  75000,   60000,    2.50),
   (15, 0, 'def',   'Geen bescherming',      0,       0,    1.00),
   (16, 2, 'def',   'Kogelvrije vest',  100000,   75000,    4.00),
   (17, 1, 'def',   'Kogelvrij schild',  30000,   20000,    2.00);

--- a/tests/geld.php
+++ b/tests/geld.php
@@ -221,6 +221,38 @@ for ($i = 1; $i < count($kolommen); $i++) {
     check($kolommen[$i - 1] . ' ligt écht boven ' . $kolommen[$i] . ' bij minstens één xp', $strikt);
 }
 
+// --- Wapens: effect --------------------------------------------------------
+
+kop('wapens: effect is een vermenigvuldiger op trefzekerheid, hoger is beter');
+
+$wapens = $db->query(
+    "SELECT naam, aprijs, effect FROM items WHERE type='att' ORDER BY aprijs"
+)->fetchAll();
+
+check('alle zes wapens staan in de catalogus', count($wapens) === 6, (string) count($wapens));
+
+$vorige = null;
+foreach ($wapens as $wapen) {
+    if ($vorige !== null) {
+        check($vorige['naam'] . ' (€' . number_format((int) $vorige['aprijs'], 0, ',', '.') . ') <= '
+            . $wapen['naam'] . ' (€' . number_format((int) $wapen['aprijs'], 0, ',', '.') . ') qua effect',
+            (float) $wapen['effect'] >= (float) $vorige['effect'],
+            $vorige['effect'] . ' -> ' . $wapen['effect']);
+    }
+    $vorige = $wapen;
+}
+
+$m16    = (float) $db->query("SELECT effect FROM items WHERE naam='M16'")->fetchColumn();
+$tommy  = (float) $db->query("SELECT effect FROM items WHERE naam='Tommy Gun'")->fetchColumn();
+check('Tommy Gun (140.000) is nu écht effectiever dan de goedkopere M16 (50.000)',
+    $tommy > $m16, "M16 {$m16} vs Tommy Gun {$tommy}");
+
+$goedkoopste = (float) $db->query(
+    "SELECT effect FROM items WHERE type='att' ORDER BY aprijs LIMIT 1"
+)->fetchColumn();
+check('zelfs het goedkoopste wapen is beter dan blote handen (effect boven de 1.0-basiswaarde)',
+    $goedkoopste > 1.0, (string) $goedkoopste);
+
 // --- Cron ------------------------------------------------------------------
 
 kop('cron: alle taken draaien');


### PR DESCRIPTION
trefzekerheid() deelde door het wapen-effect, terwijl weerstand() voor bescherming er juist mee vermenigvuldigt. Daardoor kregen wapens in install/schema.sql een lager effect naarmate ze duurder waren (9mm €10.000 -> 4.00, Sniper Rifle €100.000 -> 1.50) — het omgekeerde van bescherming, waar een hogere prijs een hoger effect geeft. Dezelfde "Effect"-kolom in de winkel las dus twee kanten op. Bovendien had de duurste Tommy Gun (€140.000) toevallig hetzelfde effect als de veel goedkopere M16 (€50.000): nul verschil in gevechtskracht voor €90.000 extra.

trefzekerheid() vermenigvuldigt nu met het wapen-effect, en de effectwaarden in install/schema.sql zijn herzien zodat ze oplopen met de prijs (1.20 t/m 4.20, ongeveer dezelfde spreiding als voorheen). adm-items.php's toelichting is bijgewerkt naar de nieuwe richting.

Live installaties: dit verandert alleen de formule en de standaardwaarden voor nieuwe installaties. Op een bestaande database moeten de zes wapens (Uzi, M16, Sniper Rifle, 9mm, Tommy Gun, Magnum Semi Auto) handmatig bijgewerkt worden via adm-items.php naar de nieuwe effectwaarden in install/schema.sql, anders draait de oude data met de nieuwe (omgekeerde) formule.

Fixes #35.